### PR TITLE
Fix concurrency calls issue in service

### DIFF
--- a/app/leave-app/backend/modules/authorization/authorization.bal
+++ b/app/leave-app/backend/modules/authorization/authorization.bal
@@ -116,5 +116,6 @@ public isolated function validateForSingleRole(readonly & CustomJwtPayload jwt, 
 # + requiredRoles - Required Role list
 # + userRoles - Roles list, the user has
 # + return - Allow or not
-public function checkRoles(string[] requiredRoles, string[] userRoles) returns boolean =>
-    userRoles.some(userRole => requiredRoles.some(role => role == userRole));
+public isolated function checkRoles(readonly & string[] requiredRoles, string[] userRoles) returns boolean =>
+    userRoles.some(isolated function(string userRole) returns boolean => requiredRoles.some(
+        isolated function(string role) returns boolean => role == userRole));

--- a/app/leave-app/backend/service.bal
+++ b/app/leave-app/backend/service.bal
@@ -210,7 +210,7 @@ service http:InterceptableService / on new http:Listener(9090) {
             if leave is error {
                 fail error(leave.message(), leave);
             }
-            LeaveResponse leaveResponse = {
+            final readonly & LeaveResponse leaveResponse = {
                 id: leave.id,
                 startDate: leave.startDate,
                 calendarEventId: leave.calendarEventId,


### PR DESCRIPTION
### Description
The following warning is given when running the service.
`concurrent calls will not be made to this method since the method is not an 'isolated' method`

### Solution
Allow for concurrency by using the proper syntax and variable manipulation.