### PR TITLE
[Leave App] Add "Test Leave" as summary and description for non prod envs

### DIFF
--- a/apps/leave-app/backend/leave_calculation.bal
+++ b/apps/leave-app/backend/leave_calculation.bal
@@ -146,12 +146,13 @@ isolated function createLeaveEventInCalendar(string email, LeaveResponse leave, 
         endTime.dateTime = string `${startDateString}T13:00:00.000`;
     }
 
+    string summary = isDebug ? "Test Leave" : "On Leave";
     log:printInfo(string `Creating event for leave id: ${id} email: ${email}.`);
     string|error? eventId = calendar_events:createEvent(
             email,
             {
-                summary: isDebug ? "Test Leave" : "On Leave",
-                description: isDebug ? "Test Leave" : "On Leave",
+                summary,
+                description: summary,
                 colorId: "4",
                 'start: startTime,
                 end: endTime,

--- a/apps/leave-app/backend/leave_calculation.bal
+++ b/apps/leave-app/backend/leave_calculation.bal
@@ -22,6 +22,7 @@ import ballerina/time;
 import ballerina/uuid;
 
 configurable decimal allowedDaysToCancelLeave = 30;
+public configurable boolean isDebug = false;
 
 # Calculates and returns the leave details for a given leave request.
 #
@@ -149,8 +150,8 @@ isolated function createLeaveEventInCalendar(string email, LeaveResponse leave, 
     string|error? eventId = calendar_events:createEvent(
             email,
             {
-                summary: "On Leave",
-                description: "On Leave",
+                summary: isDebug ? "Test Leave" : "On Leave",
+                description: isDebug ? "Test Leave" : "On Leave",
                 colorId: "4",
                 'start: startTime,
                 end: endTime,


### PR DESCRIPTION
## Description
+ Add default false config to distinguish `dev`, `stg` and `prod` environments.
+ Add the summary and description as `"Test Leave"` for `stg` and `dev` environments.