### PR TITLE
[Meet App] Enhance meetingHistory with title search & clarify disclaimerMessage behavior

### DIFF
--- a/apps/meet-app/backend/config.toml.local
+++ b/apps/meet-app/backend/config.toml.local
@@ -3,7 +3,7 @@
     calendarId = ""
     disclaimerMessage = "<h3><b>Disclaimer:</b></h3><b>This meeting has been scheduled on behalf of ${creatorEmail} using the Meet scheduling account.</b><br><br>"
     # Note:
-    # ${creatorEmail} will be dynamically replaced with the actual email of the user
+    # ${creatorEmail} will be dynamically replaced with the actual email of the logged-in user.
 
     [meet_app.calendar.oauthConfig]
         tokenUrl = ""

--- a/apps/meet-app/webapp/src/slices/meetingSlice/meeting.ts
+++ b/apps/meet-app/webapp/src/slices/meetingSlice/meeting.ts
@@ -164,13 +164,13 @@ export const addMeetings = createAsyncThunk(
 
 export const fetchMeetings = createAsyncThunk(
   "meeting/fetchMeetings",
-  async ({ limit, offset }: { limit: number; offset: number }, { dispatch }) => {
+  async ({ title, limit, offset }: { title:string, limit: number; offset: number }, { dispatch }) => {
     APIService.getCancelToken().cancel();
     const newCancelTokenSource = APIService.updateCancelToken();
     return new Promise<Meetings>((resolve, reject) => {
       APIService.getInstance()
         .get(AppConfig.serviceUrls.meetings, {
-          params: { limit, offset },
+          params: { title, limit, offset },
           cancelToken: newCancelTokenSource.token,
         })
         .then((response) => {

--- a/apps/meet-app/webapp/src/slices/meetingSlice/meeting.ts
+++ b/apps/meet-app/webapp/src/slices/meetingSlice/meeting.ts
@@ -164,13 +164,13 @@ export const addMeetings = createAsyncThunk(
 
 export const fetchMeetings = createAsyncThunk(
   "meeting/fetchMeetings",
-  async ({ title, limit, offset }: { title:string, limit: number; offset: number }, { dispatch }) => {
+  async ({ host, title, limit, offset }: { host: string, title: string, limit: number, offset: number }, { dispatch }) => {
     APIService.getCancelToken().cancel();
     const newCancelTokenSource = APIService.updateCancelToken();
     return new Promise<Meetings>((resolve, reject) => {
       APIService.getInstance()
         .get(AppConfig.serviceUrls.meetings, {
-          params: { title, limit, offset },
+          params: { host, title, limit, offset },
           cancelToken: newCancelTokenSource.token,
         })
         .then((response) => {

--- a/apps/meet-app/webapp/src/view/meetings/panel/createMeeting.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/createMeeting.tsx
@@ -278,6 +278,7 @@ function MeetingForm() {
                 onBlur={formik.handleBlur}
                 onChange={formik.handleChange}
                 error={formik.touched.meetingType && Boolean(formik.errors.meetingType)}
+                helperText={formik.touched.meetingType && formik.errors.meetingType}
               />
             )}
           />
@@ -292,6 +293,7 @@ function MeetingForm() {
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
             error={formik.touched.customerName && Boolean(formik.errors.customerName)}
+            helperText={formik.touched.customerName && formik.errors.customerName}
             autoCorrect="off"
             autoCapitalize="none"
             spellCheck={false}
@@ -323,17 +325,6 @@ function MeetingForm() {
           multiline
           rows={2}
         />
-        <FormHelperText
-          error={
-            (formik.touched.customTitle && Boolean(formik.errors.customTitle)) ||
-            (formik.touched.meetingType && Boolean(formik.errors.meetingType)) ||
-            (formik.touched.customerName && Boolean(formik.errors.customerName))
-          }
-          sx={{ marginX: "14px !important", marginBottom: "2px !important", marginTop: "0px !important" }}
-        >
-          {(formik.touched.meetingType && formik.errors.meetingType) ||
-            (formik.touched.customerName && formik.errors.customerName)}
-        </FormHelperText>
         <DatePicker
           name="date"
           label="Meeting Date *"
@@ -430,6 +421,13 @@ function MeetingForm() {
           multiple
           limitTags={1}
           options={employees.map((emp) => emp.workEmail)}
+          filterOptions={createFilterOptions({
+            stringify: (email) => {
+              const employee = employees.find((emp) => emp.workEmail === email);
+              const fullName = `${employee?.firstName || ""} ${employee?.lastName || ""}`;
+              return `${email} ${fullName}`;
+            },
+          })}
           filterSelectedOptions
           value={formik.values.internalParticipants.split(",").filter(Boolean)}
           onChange={(_, newValue) => {

--- a/apps/meet-app/webapp/src/view/meetings/panel/createMeeting.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/createMeeting.tsx
@@ -60,7 +60,7 @@ function formatDateTime(date: Dayjs | null, time: Dayjs | null): Dayjs | null {
 const validationSchema = yup.object({
   meetingType: yup.string().trim().required("Meeting type is required"),
   customerName: yup.string().trim().required("Customer name is required"),
-  customTitle: yup.string().trim().required("Title is required"),
+  customTitle: yup.string().trim(),
   description: yup.string().trim(),
   date: yup
     .mixed<Dayjs>()
@@ -165,7 +165,7 @@ function MeetingForm() {
       try {
         if (!formik.isValid) return;
         const formattedData = {
-          title: `${values.meetingType} - ${values.customerName} - ${values.customTitle}`.trim(),
+          title: [values.meetingType, values.customerName, values.customTitle?.trim()].filter(Boolean).join(" - "),
           description: values.description,
           startTime:
             values.date && values.startTime ? formatDateTime(values.date, values.startTime)?.toISOString() ?? "" : "",
@@ -237,18 +237,6 @@ function MeetingForm() {
         <Typography variant="h5" fontWeight="bold" color="primary.main" align="center">
           Create Meeting
         </Typography>
-        <TextField
-          required
-          fullWidth
-          id="customTitle"
-          name="customTitle"
-          label="Title"
-          value={formik.values.customTitle}
-          onBlur={formik.handleBlur}
-          onChange={formik.handleChange}
-          error={formik.touched.customTitle && Boolean(formik.errors.customTitle)}
-        />
-
         <Box sx={{ display: "flex", gap: 2 }}>
           <Autocomplete
             sx={{ flex: 1 }}
@@ -310,7 +298,16 @@ function MeetingForm() {
             sx={{ flex: 1 }}
           />
         </Box>
-
+        <TextField
+          fullWidth
+          id="customTitle"
+          name="customTitle"
+          label="Title"
+          value={formik.values.customTitle}
+          onBlur={formik.handleBlur}
+          onChange={formik.handleChange}
+          error={formik.touched.customTitle && Boolean(formik.errors.customTitle)}
+        />
         <TextField
           fullWidth
           id="description"
@@ -334,8 +331,7 @@ function MeetingForm() {
           }
           sx={{ marginX: "14px !important", marginBottom: "2px !important", marginTop: "0px !important" }}
         >
-          {(formik.touched.customTitle && formik.errors.customTitle) ||
-            (formik.touched.meetingType && formik.errors.meetingType) ||
+          {(formik.touched.meetingType && formik.errors.meetingType) ||
             (formik.touched.customerName && formik.errors.customerName)}
         </FormHelperText>
         <DatePicker

--- a/apps/meet-app/webapp/src/view/meetings/panel/createMeeting.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/createMeeting.tsx
@@ -530,9 +530,10 @@ function MeetingForm() {
           options={externalEmailInputValue.filter((email) => email.trim() !== "")}
           filterSelectedOptions
           value={formik.values.externalParticipants.split(",").filter(Boolean)}
-          onChange={(_, newValue) => {
+          onChange={async (_, newValue) => {
             const emails = newValue.map((email) => email.trim()).filter(Boolean);
-            formik.setFieldValue("externalParticipants", emails.join(","));
+            await formik.setFieldValue("externalParticipants", emails.join(","));
+            formik.setFieldTouched("externalParticipants", true);
           }}
           onInputChange={(_, newInputValue) => {
             setExternalEmailInputValue([newInputValue]);

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -1,3 +1,19 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import {
   Box,
   Button,
@@ -109,9 +125,9 @@ function MeetingHistory() {
       flex: 1,
       headerAlign: "center",
       align: "center",
+      disableColumnMenu: true,
       renderCell: (params) => {
         const status = params.value;
-
         return (
           <Tooltip title={status === "ACTIVE" ? "Active" : "Cancelled"} arrow>
             <Box
@@ -155,13 +171,14 @@ function MeetingHistory() {
       renderCell: (params) => formatDateTime(params.value),
     },
     {
-      field: "actions",
-      headerName: "Actions",
-      minWidth: 90,
+      field: "attachments",
+      headerName: "Attachments",
+      minWidth: 100,
       flex: 1,
+      headerAlign: "center",
+      align: "center",
+      disableColumnMenu: true,
       renderCell: (params) => {
-        const isCancelled = params.row.meetingStatus === "CANCELLED";
-
         return (
           <>
             <Tooltip title="View Attachments" arrow>
@@ -169,6 +186,22 @@ function MeetingHistory() {
                 <Visibility />
               </IconButton>
             </Tooltip>
+          </>
+        );
+      },
+    },
+    {
+      field: "delete",
+      headerName: "Delete",
+      minWidth: 90,
+      flex: 1,
+      headerAlign: "center",
+      align: "center",
+      disableColumnMenu: true,
+      renderCell: (params) => {
+        const isCancelled = params.row.meetingStatus === "CANCELLED";
+        return (
+          <>
             {!isCancelled && (
               <Tooltip title="Delete Meeting" arrow>
                 <IconButton

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -254,7 +254,7 @@ function MeetingHistory() {
           sx={{
             width: 300,
             "& .MuiInputBase-root": {
-              paddingRight: 0, // Remove any extra padding on the right
+              paddingRight: 0,
             },
           }}
           InputProps={{
@@ -265,14 +265,8 @@ function MeetingHistory() {
                   setPage(0);
                 }}
                 sx={{
-                  // padding: 0, // Remove padding around the icon
-                  // height: "100%", // Make the button fill the full height of the text field
-                  // width: "40px", // Adjust width to match the size of the icon
-                  justifyContent: "center", // Center the icon horizontally
-                  borderRadius: 0, // Remove the circular border radius
-                  // "&:hover": {
-                  //   backgroundColor: "#f0f0f0", // Change background color on hover
-                  // },
+                  justifyContent: "center",
+                  borderRadius: 0,
                 }}
               >
                 <Search />

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -69,9 +69,12 @@ function MeetingHistory() {
   const [openAttachmentDialog, setOpenAttachmentDialog] = useState(false);
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [filteredSearchQuery, setFilteredSearchQuery] = useState<string>("");
+  const loggedInUser = useAppSelector((state) => state.user.userInfo?.workEmail) || "";
 
   useEffect(() => {
-    dispatch(fetchMeetings({ title: filteredSearchQuery, limit: pageSize, offset: page * pageSize }));
+    dispatch(
+      fetchMeetings({ host: loggedInUser, title: filteredSearchQuery, limit: pageSize, offset: page * pageSize })
+    );
   }, [dispatch, filteredSearchQuery, page, pageSize]);
 
   const handleDeleteMeeting = (meetingId: number, meetingTitle: string) => {
@@ -92,7 +95,9 @@ function MeetingHistory() {
         setLoadingDelete(true);
         await dispatch(deleteMeeting(meetingId)).then(() => {
           setLoadingDelete(false);
-          dispatch(fetchMeetings({ title: filteredSearchQuery, limit: pageSize, offset: page * pageSize }));
+          dispatch(
+            fetchMeetings({ host: loggedInUser, title: filteredSearchQuery, limit: pageSize, offset: page * pageSize })
+          );
         });
       },
       "Yes",


### PR DESCRIPTION
## Purpose
> Implemented a new "Search by Title" feature on the meetingHistory page to enhance usability and improve content filtering for users.

> Added a comment in config.toml to clarify that the ${creatorEmail} placeholder in the disclaimerMessage field is dynamically replaced with the meeting creator’s email at runtime.