### PR TITLE
[Meet App] Use end date for recurring meetings

### DIFF
--- a/apps/meet-app/backend/modules/calendar/calendar.bal
+++ b/apps/meet-app/backend/modules/calendar/calendar.bal
@@ -54,7 +54,7 @@ public isolated function createCalendarEvent(CreateCalendarEventRequest createCa
     if isRecurring {
         RecurrenceConfig? recurrenceSpec = createCalendarEventRequest?.recurrence;
         if recurrenceSpec is RecurrenceConfig {
-            string rule = string `RRULE:FREQ=${recurrenceSpec.frequency.toUpperAscii()};COUNT=${recurrenceSpec.count}`;
+            string rule = string `RRULE:FREQ=${recurrenceSpec.frequency.toUpperAscii()};UNTIL=${recurrenceSpec.untilUtc}`;
             recurrenceArray = [rule];
         }
     }

--- a/apps/meet-app/backend/modules/calendar/types.bal
+++ b/apps/meet-app/backend/modules/calendar/types.bal
@@ -40,8 +40,8 @@ public type CalendarRetryConfig record {|
 public type RecurrenceConfig record {|
     # Recurrence frequency
     string frequency;
-    # Number of occurrences
-    int count;
+    # End of the recurrence series in UTC
+    string untilUtc;
 |};
 
 # Event create request record.

--- a/apps/meet-app/webapp/src/slices/meetingSlice/meeting.ts
+++ b/apps/meet-app/webapp/src/slices/meetingSlice/meeting.ts
@@ -58,7 +58,7 @@ interface AddMeetingPayload {
   timeZone: string;
   internalParticipants: string[];
   externalParticipants: string[];
-  recurrence?: { frequency: "DAILY" | "WEEKLY" | "MONTHLY"; count: number };
+  recurrence?: { frequency: "DAILY" | "WEEKLY" | "MONTHLY"; untilUtc: string };
   recurrenceRule?: string | null;
   isRecurring?: boolean;
 }


### PR DESCRIPTION
## Purpose
> Replace the old occurrence-based recurrence flow with an explicit end-date model, improving user clarity and preventing misconfigured recurring meetings. This update also enhances form behaviour and aligns recurrence logic with standard calendar expectations.

## Goals
> Simplify recurring meeting setup by adding an end date, removing the occurrence number, and keeping behaviour consistent across validation and UX.

**Purpose**
> Replace occurrence-based recurrence with an explicit end date and clearer error handling to reduce confusion and ensure accurate scheduling across time zones.

**Updated**
> Added recurrenceEndDate with full validation, reused formatDateTime to build untilUtc, unified Repeat/End-Date error helper text so both inputs move together, improved UX alignment, and removed outdated recurrence fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Recurring meetings now configured using an end date instead of a fixed occurrence count for greater scheduling flexibility.
  * Meeting creation form updated with an end date picker to specify when recurring meetings should stop.

* **Improvements**
  * Enhanced validation for recurring meeting end dates to ensure they occur on or after the meeting start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->