### PR TITLE
[Meet App]feat: enhance meeting history with admin role checks and improved column rendering

### DIFF
--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -560,16 +560,6 @@ service http:InterceptableService / on new http:Listener(9090) {
                 }
             };
         }
-        boolean isAdmin = authorization:checkPermissions([authorization:authorizedRoles.SALES_ADMIN], userInfo.groups);
-        if (!isAdmin && (host != ()) && (host != userInfo.email)) {
-            string customError = "Insufficient privileges to filter by host!";
-            log:printError(customError);
-            return <http:Forbidden>{
-                body: {
-                    message: customError
-                }
-            };
-        }
         if (searchString is string && (host is string || title is string)) {
             string customError = "searchString cannot be combined with host or title filters.";
             log:printError(customError);
@@ -579,8 +569,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                 }
             };
         }
-        string? hostOrInternalParticipant = (host is () && !isAdmin) ? userInfo.email : null;
-        database:Meeting[]|error meetings = database:fetchMeetings(hostOrInternalParticipant, title, host, searchString, region,
+        database:Meeting[]|error meetings = database:fetchMeetings(null, title, host, searchString, region,
                 startTime, endTime, internalParticipants, 'limit, offset);
         if meetings is error {
             string customError = "Error occurred while retrieving the meetings!";

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -580,26 +580,21 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
         string? hostOrInternalParticipant = (host is () && !isAdmin) ? userInfo.email : null;
-        database:Meeting[]|error meetingsResult = database:fetchMeetings(hostOrInternalParticipant, title, host, searchString, region,
+        database:Meeting[]|error meetings = database:fetchMeetings(hostOrInternalParticipant, title, host, searchString, region,
                 startTime, endTime, internalParticipants, 'limit, offset);
-        if meetingsResult is error {
+        if meetings is error {
             string customError = "Error occurred while retrieving the meetings!";
-            log:printError(customError, meetingsResult);
+            log:printError(customError, meetings);
             return <http:InternalServerError>{
                 body: {
                     message: customError
                 }
             };
         }
-        database:Meeting[] meetingList = meetingsResult;
-        if !isAdmin {
-            meetingList = from var meeting in meetingList
-                where meeting.host == userInfo.email
-                select meeting;
-        }
+
         return {
-            count: (meetingList.length() > 0) ? meetingList[0].totalCount : 0,
-            meetings: from var meeting in meetingList
+            count: (meetings.length() > 0) ? meetings[0].totalCount : 0,
+            meetings: from var meeting in meetings
                 select {
                     meetingId: meeting.meetingId,
                     title: meeting.title,
@@ -838,7 +833,7 @@ service http:InterceptableService / on new http:Listener(9090) {
             }
 
             // Drive API
-            future<int|error> fDrive = start drive:countWso2RecordingsInDateRange(queryStartTime, queryEndTime,region);
+            future<int|error> fDrive = start drive:countWso2RecordingsInDateRange(queryStartTime, queryEndTime, region);
             driveFutureMap[monthKey] = fDrive;
             metaDataMap[monthKey] = {
                 "year": cursorYear,

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -56,6 +56,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 import StyledRadio from "@root/src/component/ui/StyledRadio";
 import Chip from "@mui/material/Chip";
 import Stack from "@mui/material/Stack";
+import { Role } from "@root/src/slices/authSlice/auth";
 
 interface Attachment {
   title: string;
@@ -87,6 +88,7 @@ function MeetingHistory() {
   const dispatch = useAppDispatch();
   const meeting = useAppSelector((state) => state.meeting);
   const regions = useAppSelector((state) => state.region);
+  const privileges = useAppSelector((state) => state.auth);
   const totalMeetings = meeting.meetings?.count || 0;
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
@@ -102,6 +104,7 @@ function MeetingHistory() {
   const [regionOption, setRegionRangeOption] = useState<string>("All");
   const [meetingType, setMeetingType] = useState("Past");
   const [endDate, setEndDate] = useState(() => formatDateForInput(new Date()));
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const handleRadioButtonChange = (event: ChangeEvent<HTMLInputElement>) => {
     const selectedValue = event.target.value;
     setMeetingType(selectedValue);
@@ -133,6 +136,12 @@ function MeetingHistory() {
     meetingType,
     endDate,
   ]);
+
+  useEffect(() => {
+    if (privileges.status === State.success) {
+      setIsAdmin(privileges.roles.includes(Role.ADMIN));
+    }
+  }, []);
 
   useEffect(() => {
     if (regions.state === State.idle) {
@@ -201,228 +210,238 @@ function MeetingHistory() {
     setAttachments([]);
   };
 
-  const columns: GridColDef[] = [
-    {
-      field: "title",
-      headerName: "Title",
-      minWidth: 300,
-      flex: 5,
-      renderCell: (params) => {
-        const title = params.value;
-        const isUpcoming = params.row.timeStatus === "UPCOMING";
-        return (
-          <Stack
-            direction="row"
-            spacing={1}
-            alignItems="center"
-            sx={{ height: "100%" }}
-          >
-            <Typography variant="body2" noWrap>
-              {title}
-            </Typography>
-            {isUpcoming && (
-              <Chip
-                label="Upcoming"
-                size="small"
-                color="primary"
-                sx={{ height: 20, fontSize: "0.65rem" }}
-              />
-            )}
-          </Stack>
-        );
-      },
-    },
-    {
-      field: "meetingStatus",
-      headerName: "Status",
-      minWidth: 100,
-      flex: 1,
-      headerAlign: "center",
-      align: "center",
-      disableColumnMenu: true,
-      renderCell: (params) => {
-        const status = params.value;
-        return (
-          <Tooltip title={status === "ACTIVE" ? "Active" : "Cancelled"} arrow>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                height: "100%",
-              }}
+  const columns: GridColDef[] = useMemo(() => {
+    const baseColumns: GridColDef[] = [
+      {
+        field: "title",
+        headerName: "Title",
+        minWidth: 300,
+        flex: 5,
+        renderCell: (params) => {
+          const title = params.value;
+          const isUpcoming = params.row.timeStatus === "UPCOMING";
+          return (
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              sx={{ height: "100%" }}
             >
-              {status === "ACTIVE" ? (
-                <CheckCircle color="success" />
-              ) : (
-                <Delete color="disabled" />
+              <Typography variant="body2" noWrap>
+                {title}
+              </Typography>
+              {isUpcoming && (
+                <Chip
+                  label="Upcoming"
+                  size="small"
+                  color="primary"
+                  sx={{ height: 20, fontSize: "0.65rem" }}
+                />
               )}
-            </Box>
-          </Tooltip>
-        );
+            </Stack>
+          );
+        },
       },
-    },
-    {
-      field: "isRecurring",
-      headerName: "Recurring",
-      minWidth: 100,
-      flex: 1,
-      headerAlign: "center",
-      align: "center",
-      disableColumnMenu: true,
-      renderCell: (params) => {
-        const recurring = Boolean(params.value);
-        return (
-          <Tooltip
-            title={recurring ? "Recurring series" : "One-off meeting"}
-            arrow
-          >
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                height: "100%",
-              }}
-            >
-              {recurring ? (
-                <Loop color="info" />
-              ) : (
-                <RemoveCircleOutline color="disabled" />
-              )}
-            </Box>
-          </Tooltip>
-        );
-      },
-    },
-    {
-      field: "host",
-      headerName: "Host",
-      minWidth: 120,
-      flex: 2,
-    },
-    {
-      field: "internalParticipants",
-      headerName: "WSO2 Participants",
-      minWidth: 200,
-      flex: 4,
-    },
-    {
-      field: "startTime",
-      headerName: "Start Time",
-      minWidth: 120,
-      flex: 1,
-      renderCell: (params) => formatDateTime(params.value),
-    },
-    {
-      field: "endTime",
-      headerName: "End Time",
-      minWidth: 120,
-      flex: 1,
-      renderCell: (params) => formatDateTime(params.value),
-    },
-    {
-      field: "attachments",
-      headerName: "Attachments",
-      minWidth: 100,
-      flex: 1,
-      headerAlign: "center",
-      align: "center",
-      disableColumnMenu: true,
-      renderCell: (params) => {
-        return (
-          <>
-            <Tooltip title="View Attachments" arrow>
-              <IconButton
-                color="info"
-                onClick={() => handleViewAttachments(params.row.meetingId)}
+      {
+        field: "meetingStatus",
+        headerName: "Status",
+        minWidth: 100,
+        flex: 1,
+        headerAlign: "center",
+        align: "center",
+        disableColumnMenu: true,
+        renderCell: (params) => {
+          const status = params.value;
+          return (
+            <Tooltip title={status === "ACTIVE" ? "Active" : "Cancelled"} arrow>
+              <Box
                 sx={{
-                  backgroundColor: (theme) => theme.palette.info.main,
-                  borderRadius: 2,
-                  width: 25,
-                  height: 25,
-                  border: (theme) => `2px solid ${theme.palette.info.dark}`,
-                  boxShadow: (theme) =>
-                    `0 2px 4px ${theme.palette.info.dark}30`,
-                  "&:hover": {
-                    backgroundColor: (theme) => theme.palette.info.dark,
-                    transform: "translateY(-1px)",
-                    boxShadow: (theme) =>
-                      `0 4px 8px ${theme.palette.info.dark}40`,
-                  },
-                  "&:active": {
-                    transform: "translateY(0px)",
-                    boxShadow: (theme) =>
-                      `0 1px 2px ${theme.palette.info.dark}60`,
-                  },
-                  "& .MuiSvgIcon-root": {
-                    color: (theme) => theme.palette.info.contrastText,
-                    fontSize: "1.1rem",
-                  },
-                  transition: "all 0.2s ease-in-out",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
                 }}
               >
-                <Visibility />
-              </IconButton>
+                {status === "ACTIVE" ? (
+                  <CheckCircle color="success" />
+                ) : (
+                  <Delete color="disabled" />
+                )}
+              </Box>
             </Tooltip>
-          </>
-        );
+          );
+        },
       },
-    },
-    {
-      field: "delete",
-      headerName: "Delete",
-      minWidth: 90,
-      flex: 1,
-      headerAlign: "center",
-      align: "center",
-      disableColumnMenu: true,
-      renderCell: (params) => {
-        const isCancelled = params.row.meetingStatus === "CANCELLED";
-        return (
-          <>
-            {!isCancelled && (
-              <Tooltip title="Delete Meeting" arrow>
+      {
+        field: "isRecurring",
+        headerName: "Recurring",
+        minWidth: 100,
+        flex: 1,
+        headerAlign: "center",
+        align: "center",
+        disableColumnMenu: true,
+        renderCell: (params) => {
+          const recurring = Boolean(params.value);
+          return (
+            <Tooltip
+              title={recurring ? "Recurring series" : "One-off meeting"}
+              arrow
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
+                }}
+              >
+                {recurring ? (
+                  <Loop color="info" />
+                ) : (
+                  <RemoveCircleOutline color="disabled" />
+                )}
+              </Box>
+            </Tooltip>
+          );
+        },
+      },
+      {
+        field: "host",
+        headerName: "Host",
+        minWidth: 120,
+        flex: 2,
+      },
+      {
+        field: "internalParticipants",
+        headerName: "WSO2 Participants",
+        minWidth: 200,
+        flex: 4,
+      },
+      {
+        field: "startTime",
+        headerName: "Start Time",
+        minWidth: 120,
+        flex: 1,
+        renderCell: (params) => formatDateTime(params.value),
+      },
+      {
+        field: "endTime",
+        headerName: "End Time",
+        minWidth: 120,
+        flex: 1,
+        renderCell: (params) => formatDateTime(params.value),
+      },
+      {
+        field: "attachments",
+        headerName: "Attachments",
+        minWidth: 100,
+        flex: 1,
+        headerAlign: "center",
+        align: "center",
+        disableColumnMenu: true,
+        renderCell: (params) => {
+          return (
+            <>
+              <Tooltip title="View Attachments" arrow>
                 <IconButton
-                  color="error"
-                  onClick={() => {
-                    handleDeleteMeeting(params.row.meetingId, params.row.title);
-                  }}
+                  color="info"
+                  onClick={() => handleViewAttachments(params.row.meetingId)}
                   sx={{
-                    backgroundColor: (theme) => theme.palette.error.main,
+                    backgroundColor: (theme) => theme.palette.info.main,
                     borderRadius: 2,
                     width: 25,
                     height: 25,
-                    border: (theme) => `2px solid ${theme.palette.error.dark}`,
+                    border: (theme) => `2px solid ${theme.palette.info.dark}`,
                     boxShadow: (theme) =>
-                      `0 2px 4px ${theme.palette.error.dark}30`,
+                      `0 2px 4px ${theme.palette.info.dark}30`,
                     "&:hover": {
-                      backgroundColor: (theme) => theme.palette.error.dark,
+                      backgroundColor: (theme) => theme.palette.info.dark,
                       transform: "translateY(-1px)",
                       boxShadow: (theme) =>
-                        `0 4px 8px ${theme.palette.error.dark}40`,
+                        `0 4px 8px ${theme.palette.info.dark}40`,
                     },
                     "&:active": {
                       transform: "translateY(0px)",
                       boxShadow: (theme) =>
-                        `0 1px 2px ${theme.palette.error.dark}60`,
+                        `0 1px 2px ${theme.palette.info.dark}60`,
                     },
                     "& .MuiSvgIcon-root": {
-                      color: (theme) => theme.palette.error.contrastText,
+                      color: (theme) => theme.palette.info.contrastText,
                       fontSize: "1.1rem",
                     },
                     transition: "all 0.2s ease-in-out",
                   }}
                 >
-                  <DeleteForever />
+                  <Visibility />
                 </IconButton>
               </Tooltip>
-            )}
-          </>
-        );
+            </>
+          );
+        },
       },
-    },
-  ];
+    ];
+    if (meetingType === "All") {
+      baseColumns.push({
+        field: "delete",
+        headerName: "Delete",
+        minWidth: 90,
+        flex: 1,
+        headerAlign: "center",
+        align: "center",
+        disableColumnMenu: true,
+        renderCell: (params) => {
+          const isCancelled = params.row.meetingStatus === "CANCELLED";
+          const isPast = params.row.timeStatus === "PAST";
+          return (
+            <>
+              {!isCancelled && !isPast && isAdmin && (
+                <Tooltip title="Delete Meeting" arrow>
+                  <IconButton
+                    color="error"
+                    onClick={() => {
+                      handleDeleteMeeting(
+                        params.row.meetingId,
+                        params.row.title,
+                      );
+                    }}
+                    sx={{
+                      backgroundColor: (theme) => theme.palette.error.main,
+                      borderRadius: 2,
+                      width: 25,
+                      height: 25,
+                      border: (theme) =>
+                        `2px solid ${theme.palette.error.dark}`,
+                      boxShadow: (theme) =>
+                        `0 2px 4px ${theme.palette.error.dark}30`,
+                      "&:hover": {
+                        backgroundColor: (theme) => theme.palette.error.dark,
+                        transform: "translateY(-1px)",
+                        boxShadow: (theme) =>
+                          `0 4px 8px ${theme.palette.error.dark}40`,
+                      },
+                      "&:active": {
+                        transform: "translateY(0px)",
+                        boxShadow: (theme) =>
+                          `0 1px 2px ${theme.palette.error.dark}60`,
+                      },
+                      "& .MuiSvgIcon-root": {
+                        color: (theme) => theme.palette.error.contrastText,
+                        fontSize: "1.1rem",
+                      },
+                      transition: "all 0.2s ease-in-out",
+                    }}
+                  >
+                    <DeleteForever />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </>
+          );
+        },
+      });
+    }
+    return baseColumns;
+  }, [meetingType]);
 
   const meetingList = meeting.meetings?.meetings ?? [];
 

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -176,30 +176,47 @@ function MeetingHistory() {
           setLoadingDelete(true);
           await dispatch(deleteMeeting(meetingId)).then(() => {
             setLoadingDelete(false);
-            dispatch(
-              fetchMeetings({
-                searchString: filteredSearchQuery,
-                limit: pageSize,
-                offset: page * pageSize,
-              }),
-            );
+            const params: any = {
+              searchString: filteredSearchQuery,
+              limit: pageSize,
+              offset: page * pageSize,
+            };
+
+            if (regionOption !== "All") {
+              params.region = regionOption;
+            }
+            if (meetingType === "Past") {
+              params.endTime = formatForAPI(endDate);
+            }
+            dispatch(fetchMeetings(params));
           });
         },
         "Yes",
         "No",
       );
     },
-    [dispatch, dialogContext, filteredSearchQuery, pageSize, page],
+    [
+      dispatch,
+      dialogContext,
+      filteredSearchQuery,
+      pageSize,
+      page,
+      regionOption,
+      meetingType,
+      endDate,
+    ],
   );
 
   const handleViewAttachments = useCallback(
-    (meetingId: number) => {
+    async (meetingId: number) => {
       setLoadingAttachments(true);
-      dispatch(fetchAttachments(meetingId)).then((data: any) => {
-        setAttachments(data.payload.attachments);
+      try {
+        const data = await dispatch(fetchAttachments(meetingId)).unwrap();
+        setAttachments(data.attachments ?? []);
         setOpenAttachmentDialog(true);
+      } finally {
         setLoadingAttachments(false);
-      });
+      }
     },
     [dispatch],
   );

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -156,28 +156,33 @@ function MeetingHistory() {
   const handleRegionChange = (event: SelectChangeEvent) => {
     setRegionRangeOption(event.target.value);
   };
-
   const handleDeleteMeeting = useCallback(
     (meetingId: number, meetingTitle: string) => {
       dialogContext.showConfirmation(
         "Confirm Deletion",
-        <Typography variant="body1" component="span">
-          <strong>
-            Are you sure you want to delete the meeting <br />
-          </strong>{" "}
-          {`${meetingTitle} ?`}
-        </Typography>,
+        <Box>
+          <>
+            <Typography variant="body1">
+              <strong>
+                Are you sure you want to delete the meeting <br />
+              </strong>{" "}
+              {`${meetingTitle} ?`}
+            </Typography>
+          </>
+        </Box>,
         ConfirmationType.accept,
         async () => {
           setLoadingDelete(true);
-          await dispatch(deleteMeeting(meetingId)).then(() => {
-            setLoadingDelete(false);
+          try {
+            await dispatch(deleteMeeting(meetingId)).unwrap();
             const currentItemsCount = meeting.meetings?.meetings?.length ?? 0;
             const isLastItemOnPage = currentItemsCount === 1 && page > 0;
             const newPage = isLastItemOnPage ? page - 1 : page;
+
             if (isLastItemOnPage) {
               setPage(newPage);
             }
+
             const params: any = {
               searchString: filteredSearchQuery,
               limit: pageSize,
@@ -191,7 +196,9 @@ function MeetingHistory() {
               params.endTime = formatForAPI(endDate);
             }
             dispatch(fetchMeetings(params));
-          });
+          } finally {
+            setLoadingDelete(false);
+          }
         },
         "Yes",
         "No",

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -161,25 +161,27 @@ function MeetingHistory() {
     (meetingId: number, meetingTitle: string) => {
       dialogContext.showConfirmation(
         "Confirm Deletion",
-        <Box>
-          <>
-            <Typography variant="body1">
-              <strong>
-                Are you sure you want to delete the meeting <br />
-              </strong>{" "}
-              {`${meetingTitle} ?`}
-            </Typography>
-          </>
-        </Box>,
+        <Typography variant="body1" component="span">
+          <strong>
+            Are you sure you want to delete the meeting <br />
+          </strong>{" "}
+          {`${meetingTitle} ?`}
+        </Typography>,
         ConfirmationType.accept,
         async () => {
           setLoadingDelete(true);
           await dispatch(deleteMeeting(meetingId)).then(() => {
             setLoadingDelete(false);
+            const currentItemsCount = meeting.meetings?.meetings?.length ?? 0;
+            const isLastItemOnPage = currentItemsCount === 1 && page > 0;
+            const newPage = isLastItemOnPage ? page - 1 : page;
+            if (isLastItemOnPage) {
+              setPage(newPage);
+            }
             const params: any = {
               searchString: filteredSearchQuery,
               limit: pageSize,
-              offset: page * pageSize,
+              offset: newPage * pageSize,
             };
 
             if (regionOption !== "All") {
@@ -204,6 +206,7 @@ function MeetingHistory() {
       regionOption,
       meetingType,
       endDate,
+      meeting.meetings?.meetings?.length,
     ],
   );
 
@@ -409,53 +412,82 @@ function MeetingHistory() {
           const isCancelled: boolean = params.row.meetingStatus === "CANCELLED";
           const isPast: boolean = params.row.timeStatus === "PAST";
           const host: string = params.row.host;
+          const canDelete =
+            !isCancelled &&
+            !isPast &&
+            (privileges.roles.includes(Role.ADMIN) ||
+              privileges.userInfo?.email === host);
           return (
-            <>
-              {!isCancelled &&
-                !isPast &&
-                (privileges.roles.includes(Role.ADMIN) ||
-                  privileges.userInfo?.email === host) && (
-                  <Tooltip title="Delete Meeting" arrow>
-                    <IconButton
-                      color="error"
-                      onClick={() => {
-                        handleDeleteMeeting(
-                          params.row.meetingId,
-                          params.row.title,
-                        );
-                      }}
-                      sx={{
-                        backgroundColor: (theme) => theme.palette.error.main,
-                        borderRadius: 2,
-                        width: 25,
-                        height: 25,
-                        border: (theme) =>
-                          `2px solid ${theme.palette.error.dark}`,
-                        boxShadow: (theme) =>
-                          `0 2px 4px ${theme.palette.error.dark}30`,
-                        "&:hover": {
-                          backgroundColor: (theme) => theme.palette.error.dark,
-                          transform: "translateY(-1px)",
-                          boxShadow: (theme) =>
-                            `0 4px 8px ${theme.palette.error.dark}40`,
-                        },
-                        "&:active": {
-                          transform: "translateY(0px)",
-                          boxShadow: (theme) =>
-                            `0 1px 2px ${theme.palette.error.dark}60`,
-                        },
-                        "& .MuiSvgIcon-root": {
-                          color: (theme) => theme.palette.error.contrastText,
-                          fontSize: "1.1rem",
-                        },
-                        transition: "all 0.2s ease-in-out",
-                      }}
-                    >
-                      <DeleteForever />
-                    </IconButton>
-                  </Tooltip>
-                )}
-            </>
+            <Tooltip
+              title={
+                canDelete
+                  ? "Delete Meeting"
+                  : "You do not have permission to delete this meeting"
+              }
+              arrow
+            >
+              <span>
+                <IconButton
+                  color="error"
+                  disabled={!canDelete}
+                  onClick={() => {
+                    if (canDelete) {
+                      handleDeleteMeeting(
+                        params.row.meetingId,
+                        params.row.title,
+                      );
+                    }
+                  }}
+                  sx={{
+                    backgroundColor: (theme) =>
+                      canDelete
+                        ? theme.palette.error.main
+                        : theme.palette.action.disabledBackground,
+                    borderRadius: 2,
+                    width: 25,
+                    height: 25,
+                    border: (theme) =>
+                      `2px solid ${
+                        canDelete
+                          ? theme.palette.error.dark
+                          : theme.palette.action.disabled
+                      }`,
+                    boxShadow: (theme) =>
+                      canDelete
+                        ? `0 2px 4px ${theme.palette.error.dark}30`
+                        : "none",
+                    "&:hover": {
+                      backgroundColor: (theme) =>
+                        canDelete
+                          ? theme.palette.error.dark
+                          : theme.palette.action.disabledBackground,
+                      transform: canDelete ? "translateY(-1px)" : "none",
+                      boxShadow: (theme) =>
+                        canDelete
+                          ? `0 4px 8px ${theme.palette.error.dark}40`
+                          : "none",
+                    },
+                    "&:active": {
+                      transform: "translateY(0px)",
+                      boxShadow: (theme) =>
+                        canDelete
+                          ? `0 1px 2px ${theme.palette.error.dark}60`
+                          : "none",
+                    },
+                    "& .MuiSvgIcon-root": {
+                      color: (theme) =>
+                        canDelete
+                          ? theme.palette.error.contrastText
+                          : theme.palette.action.disabled,
+                      fontSize: "1.1rem",
+                    },
+                    transition: "all 0.2s ease-in-out",
+                  }}
+                >
+                  <DeleteForever />
+                </IconButton>
+              </span>
+            </Tooltip>
           );
         },
       });
@@ -543,7 +575,7 @@ function MeetingHistory() {
           }}
         >
           <CircularProgress />
-          <Typography mt={2} color="textSecondary">
+          <Typography mt={2} color="textSecondary" component="div">
             Loading meetings, please wait...
           </Typography>
         </Box>
@@ -599,7 +631,7 @@ function MeetingHistory() {
         <DialogTitle>Attachments</DialogTitle>
         <DialogContent>
           {attachments.length === 0 ? (
-            <Typography>No attachments found.</Typography>
+            <Typography component="div">No attachments found.</Typography>
           ) : (
             <Box>
               {attachments.map((attachment, index) => (

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -104,7 +104,6 @@ function MeetingHistory() {
   const [regionOption, setRegionRangeOption] = useState<string>("All");
   const [meetingType, setMeetingType] = useState("Past");
   const [endDate, setEndDate] = useState(() => formatDateForInput(new Date()));
-  const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const handleRadioButtonChange = (event: ChangeEvent<HTMLInputElement>) => {
     const selectedValue = event.target.value;
     setMeetingType(selectedValue);
@@ -136,12 +135,6 @@ function MeetingHistory() {
     meetingType,
     endDate,
   ]);
-
-  useEffect(() => {
-    if (privileges.status === State.success) {
-      setIsAdmin(privileges.roles.includes(Role.ADMIN));
-    }
-  }, []);
 
   useEffect(() => {
     if (regions.state === State.idle) {
@@ -390,11 +383,12 @@ function MeetingHistory() {
         align: "center",
         disableColumnMenu: true,
         renderCell: (params) => {
-          const isCancelled = params.row.meetingStatus === "CANCELLED";
-          const isPast = params.row.timeStatus === "PAST";
+          const isCancelled:boolean = params.row.meetingStatus === "CANCELLED";
+          const isPast:boolean = params.row.timeStatus === "PAST";
+          const host:string = params.row.host;
           return (
             <>
-              {!isCancelled && !isPast && isAdmin && (
+              {(!isCancelled && !isPast && (privileges.roles.includes(Role.ADMIN) || privileges.userInfo?.email === host)) && (
                 <Tooltip title="Delete Meeting" arrow>
                   <IconButton
                     color="error"
@@ -441,7 +435,7 @@ function MeetingHistory() {
       });
     }
     return baseColumns;
-  }, [meetingType]);
+  }, [meetingType,privileges,handleDeleteMeeting]);
 
   const meetingList = meeting.meetings?.meetings ?? [];
 

--- a/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
+++ b/apps/meet-app/webapp/src/view/meetings/panel/meetingHistory.tsx
@@ -30,7 +30,7 @@ import {
   SelectChangeEvent,
 } from "@mui/material";
 import { DropdownOption, State } from "@/types/types";
-import { ChangeEvent, useEffect, useMemo, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useState, useCallback } from "react";
 import { ConfirmationType } from "@/types/types";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import ErrorHandler from "@component/common/ErrorHandler";
@@ -157,46 +157,52 @@ function MeetingHistory() {
     setRegionRangeOption(event.target.value);
   };
 
-  const handleDeleteMeeting = (meetingId: number, meetingTitle: string) => {
-    dialogContext.showConfirmation(
-      "Confirm Deletion",
-      <Box>
-        <>
-          <Typography variant="body1">
-            <strong>
-              Are you sure you want to delete the meeting <br />
-            </strong>{" "}
-            {`${meetingTitle} ?`}
-          </Typography>
-        </>
-      </Box>,
-      ConfirmationType.accept,
-      async () => {
-        setLoadingDelete(true);
-        await dispatch(deleteMeeting(meetingId)).then(() => {
-          setLoadingDelete(false);
-          dispatch(
-            fetchMeetings({
-              searchString: filteredSearchQuery,
-              limit: pageSize,
-              offset: page * pageSize,
-            }),
-          );
-        });
-      },
-      "Yes",
-      "No",
-    );
-  };
+  const handleDeleteMeeting = useCallback(
+    (meetingId: number, meetingTitle: string) => {
+      dialogContext.showConfirmation(
+        "Confirm Deletion",
+        <Box>
+          <>
+            <Typography variant="body1">
+              <strong>
+                Are you sure you want to delete the meeting <br />
+              </strong>{" "}
+              {`${meetingTitle} ?`}
+            </Typography>
+          </>
+        </Box>,
+        ConfirmationType.accept,
+        async () => {
+          setLoadingDelete(true);
+          await dispatch(deleteMeeting(meetingId)).then(() => {
+            setLoadingDelete(false);
+            dispatch(
+              fetchMeetings({
+                searchString: filteredSearchQuery,
+                limit: pageSize,
+                offset: page * pageSize,
+              }),
+            );
+          });
+        },
+        "Yes",
+        "No",
+      );
+    },
+    [dispatch, dialogContext, filteredSearchQuery, pageSize, page],
+  );
 
-  const handleViewAttachments = (meetingId: number) => {
-    setLoadingAttachments(true);
-    dispatch(fetchAttachments(meetingId)).then((data: any) => {
-      setAttachments(data.payload.attachments);
-      setOpenAttachmentDialog(true);
-      setLoadingAttachments(false);
-    });
-  };
+  const handleViewAttachments = useCallback(
+    (meetingId: number) => {
+      setLoadingAttachments(true);
+      dispatch(fetchAttachments(meetingId)).then((data: any) => {
+        setAttachments(data.payload.attachments);
+        setOpenAttachmentDialog(true);
+        setLoadingAttachments(false);
+      });
+    },
+    [dispatch],
+  );
 
   const handleCloseAttachmentDialog = () => {
     setOpenAttachmentDialog(false);
@@ -383,59 +389,62 @@ function MeetingHistory() {
         align: "center",
         disableColumnMenu: true,
         renderCell: (params) => {
-          const isCancelled:boolean = params.row.meetingStatus === "CANCELLED";
-          const isPast:boolean = params.row.timeStatus === "PAST";
-          const host:string = params.row.host;
+          const isCancelled: boolean = params.row.meetingStatus === "CANCELLED";
+          const isPast: boolean = params.row.timeStatus === "PAST";
+          const host: string = params.row.host;
           return (
             <>
-              {(!isCancelled && !isPast && (privileges.roles.includes(Role.ADMIN) || privileges.userInfo?.email === host)) && (
-                <Tooltip title="Delete Meeting" arrow>
-                  <IconButton
-                    color="error"
-                    onClick={() => {
-                      handleDeleteMeeting(
-                        params.row.meetingId,
-                        params.row.title,
-                      );
-                    }}
-                    sx={{
-                      backgroundColor: (theme) => theme.palette.error.main,
-                      borderRadius: 2,
-                      width: 25,
-                      height: 25,
-                      border: (theme) =>
-                        `2px solid ${theme.palette.error.dark}`,
-                      boxShadow: (theme) =>
-                        `0 2px 4px ${theme.palette.error.dark}30`,
-                      "&:hover": {
-                        backgroundColor: (theme) => theme.palette.error.dark,
-                        transform: "translateY(-1px)",
+              {!isCancelled &&
+                !isPast &&
+                (privileges.roles.includes(Role.ADMIN) ||
+                  privileges.userInfo?.email === host) && (
+                  <Tooltip title="Delete Meeting" arrow>
+                    <IconButton
+                      color="error"
+                      onClick={() => {
+                        handleDeleteMeeting(
+                          params.row.meetingId,
+                          params.row.title,
+                        );
+                      }}
+                      sx={{
+                        backgroundColor: (theme) => theme.palette.error.main,
+                        borderRadius: 2,
+                        width: 25,
+                        height: 25,
+                        border: (theme) =>
+                          `2px solid ${theme.palette.error.dark}`,
                         boxShadow: (theme) =>
-                          `0 4px 8px ${theme.palette.error.dark}40`,
-                      },
-                      "&:active": {
-                        transform: "translateY(0px)",
-                        boxShadow: (theme) =>
-                          `0 1px 2px ${theme.palette.error.dark}60`,
-                      },
-                      "& .MuiSvgIcon-root": {
-                        color: (theme) => theme.palette.error.contrastText,
-                        fontSize: "1.1rem",
-                      },
-                      transition: "all 0.2s ease-in-out",
-                    }}
-                  >
-                    <DeleteForever />
-                  </IconButton>
-                </Tooltip>
-              )}
+                          `0 2px 4px ${theme.palette.error.dark}30`,
+                        "&:hover": {
+                          backgroundColor: (theme) => theme.palette.error.dark,
+                          transform: "translateY(-1px)",
+                          boxShadow: (theme) =>
+                            `0 4px 8px ${theme.palette.error.dark}40`,
+                        },
+                        "&:active": {
+                          transform: "translateY(0px)",
+                          boxShadow: (theme) =>
+                            `0 1px 2px ${theme.palette.error.dark}60`,
+                        },
+                        "& .MuiSvgIcon-root": {
+                          color: (theme) => theme.palette.error.contrastText,
+                          fontSize: "1.1rem",
+                        },
+                        transition: "all 0.2s ease-in-out",
+                      }}
+                    >
+                      <DeleteForever />
+                    </IconButton>
+                  </Tooltip>
+                )}
             </>
           );
         },
       });
     }
     return baseColumns;
-  }, [meetingType,privileges,handleDeleteMeeting]);
+  }, [meetingType, privileges, handleDeleteMeeting, handleViewAttachments]);
 
   const meetingList = meeting.meetings?.meetings ?? [];
 


### PR DESCRIPTION
## Purpose
Enhance the meeting history functionality by introducing role-based access control for actions and improving how columns are rendered in the meeting history table.

## Goals
- Allow all users to view the complete meeting history.
- Restrict meeting-related actions (such as delete) to admin users only.
- Improve the column rendering logic to support the updated behavior.

## Approach
- Added admin role checks before enabling meeting actions.
- Updated the meeting history table column rendering to conditionally display actions based on the user's role.
- Ensured that all users can still access and view the list of meetings without restrictions.

## Result
- All users can view meeting history.
- Only admins can perform actions on meetings.
- Cleaner and more controlled UI behavior based on user roles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins and meeting hosts can delete upcoming meetings from the meeting history panel; delete is disabled for past or cancelled meetings.

* **Bug Fixes**
  * Meeting retrieval no longer applies host-based filtering, returning consistent unfiltered results.

* **UI Improvements**
  * Conditional table column rendering, improved View Attachments flow and loading states, and pagination now adjusts correctly after deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->