### PR TITLE
[Meet App] feat: integrate Google Meet creation with calendar service and enhance event creation flow

### DIFF
--- a/apps/meet-app/backend/modules/calendar/calendar.bal
+++ b/apps/meet-app/backend/modules/calendar/calendar.bal
@@ -109,10 +109,11 @@ public isolated function createCalendarEvent(CreateCalendarEventRequest createCa
 # Delete an event from the calendar.
 #
 # + eventId - Event Id
+# + creatorEmail - Event creator Email
 # + return - JSON response if successful, else an error
-public isolated function deleteCalendarEvent(string eventId) returns DeleteCalendarEventResponse|error {
+public isolated function deleteCalendarEvent(string eventId , string creatorEmail ) returns DeleteCalendarEventResponse|error {
 
-    http:Response response = check calendarClient->delete(string `/events/${calendarId}/${eventId}`);
+    http:Response response = check calendarClient->delete(string `/events/${creatorEmail}/${eventId}`);
 
     if response.statusCode == 200 {
         json responseJson = check response.getJsonPayload();
@@ -128,10 +129,11 @@ public isolated function deleteCalendarEvent(string eventId) returns DeleteCalen
 # Get an event from the calendar.
 #
 # + eventId - Event Id
+# + creatorEmail - Event creator Email
 # + return - JSON response if successful, else an error
-public isolated function getCalendarEventAttachments(string eventId) returns gcalendar:Attachment[]|error? {
+public isolated function getCalendarEventAttachments(string eventId, string creatorEmail) returns gcalendar:Attachment[]|error? {
 
-    http:Response response = check calendarClient->get(string `/calendars/${calendarId}/events/${eventId}`);
+    http:Response response = check calendarClient->get(string `/calendars/${creatorEmail}/events/${eventId}`);
 
     if response.statusCode == 200 {
         json responseJson = check response.getJsonPayload();
@@ -149,10 +151,11 @@ public isolated function getCalendarEventAttachments(string eventId) returns gca
 # Get a calendar event.
 #
 # + eventId - Event Id
+# + creatorEmail - Event creator Email
 # + return - The event if successful, else an error
-public isolated function getCalendarEvent(string eventId) returns gcalendar:Event|error {
+public isolated function getCalendarEvent(string eventId, string creatorEmail) returns gcalendar:Event|error {
 
-    http:Response response = check calendarClient->get(string `/calendars/${calendarId}/events/${eventId}`);
+    http:Response response = check calendarClient->get(string `/calendars/${creatorEmail}/events/${eventId}`);
 
     if response.statusCode == 200 {
         json responseJson = check response.getJsonPayload();
@@ -167,11 +170,12 @@ public isolated function getCalendarEvent(string eventId) returns gcalendar:Even
 # Get all instances of a recurring event.
 #
 # + eventId - The master event Id
+# + creatorEmail - Event creator Email
 # + return - Array of event instances if successful, else an error
-public isolated function getEventInstances(string eventId) returns gcalendar:Event[]|error {
+public isolated function getEventInstances(string eventId, string creatorEmail) returns gcalendar:Event[]|error {
 
     http:Response response = check calendarClient->get(
-        string `/calendars/${calendarId}/events/${eventId}/instances`
+        string `/calendars/${creatorEmail}/events/${eventId}/instances`
     );
 
     if response.statusCode == 200 {

--- a/apps/meet-app/backend/modules/calendar/calendar.bal
+++ b/apps/meet-app/backend/modules/calendar/calendar.bal
@@ -24,9 +24,10 @@ configurable string disclaimerMessage = ?;
 #
 # + createCalendarEventRequest - Create calendar event request
 # + creatorEmail - Event creator Email
+# + meetUri - Meet URL
 # + return - JSON response if successful, else an error
 public isolated function createCalendarEvent(CreateCalendarEventRequest createCalendarEventRequest,
-        string creatorEmail) returns CreateCalendarEventResponse|error {
+        string creatorEmail, string? meetUri) returns CreateCalendarEventResponse|error {
 
     // Internal participants validation.
     string:RegExp wso2EmailDomainRegex = re `(?i:^([a-z0-9_\-\.]+)@wso2\.com$)`;
@@ -85,13 +86,14 @@ public isolated function createCalendarEvent(CreateCalendarEventRequest createCa
                     'type: CONFERENCE_SOLUTION_TYPE
                 }
             }
-        }
+        },
+        meetUri: meetUri is string ? meetUri : null
     };
 
     http:Request req = new;
     json calendarEventPayloadJson = calendarEventPayload.toJson();
     req.setPayload(calendarEventPayloadJson);
-    http:Response response = check calendarClient->post(string `/events/${calendarId}?sendUpdates=all`, req);
+    http:Response response = check calendarClient->post(string `/events/${creatorEmail}?sendUpdates=all`, req);
 
     if response.statusCode == 201 {
         json responseJson = check response.getJsonPayload();

--- a/apps/meet-app/backend/modules/calendar/meet.bal
+++ b/apps/meet-app/backend/modules/calendar/meet.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License. 
+import ballerina/http;
+
+# Create a meet
+# 
+# + return - Meet Uri
+public isolated function createMeet() returns error|string {
+    http:Response meetResponse = check calendarClient->post(string `/meet/${calendarId}`, {});
+    json meetJsonPayload = check meetResponse.getJsonPayload();
+    string extractedMeetUri = check meetJsonPayload.id;
+    return extractedMeetUri;
+}

--- a/apps/meet-app/backend/modules/calendar/meet.bal
+++ b/apps/meet-app/backend/modules/calendar/meet.bal
@@ -20,7 +20,11 @@ import ballerina/http;
 # + return - Meet Uri
 public isolated function createMeet() returns error|string {
     http:Response meetResponse = check calendarClient->post(string `/meet/${calendarId}`, {});
+    if meetResponse.statusCode === 201 {
     json meetJsonPayload = check meetResponse.getJsonPayload();
     string extractedMeetUri = check meetJsonPayload.id;
     return extractedMeetUri;
+    }
+    json? errorResponseBody = check meetResponse.getJsonPayload();
+    return error(string `Status: ${meetResponse.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
 }

--- a/apps/meet-app/backend/modules/calendar/types.bal
+++ b/apps/meet-app/backend/modules/calendar/types.bal
@@ -101,6 +101,8 @@ public type CreateCalendarEventPayload record {|
             |} conferenceSolutionKey;
         |} createRequest;
     |} conferenceData;
+    # Meet Uri
+    string? meetUri = ();
 |};
 
 # Event create success response record.

--- a/apps/meet-app/backend/modules/database/db_functions.bal
+++ b/apps/meet-app/backend/modules/database/db_functions.bal
@@ -151,6 +151,7 @@ public isolated function getMeetingCountsByHost(string startTime, string endTime
     return from MeetingHostStat stat in resultStream
         select stat;
 }
+
 # Fetches meeting titles by region within a date range.
 #
 # + startTime - Start ISO string
@@ -163,4 +164,16 @@ public isolated function getMeetingIdsByRegions(string startTime, string endTime
 
     return from var row in titleStream
         select row.title;
+}
+
+# Fetches event creator by google event Id.
+# 
+# + googleEventId - Google Event Id
+# + return - Creator of google event id or error, if not found
+public isolated function getEventCreatorByGoogleEventId(string googleEventId) returns string|error? {
+    string|sql:Error eventCreator = databaseClient->queryRow(creatorEmailByGoogleEventId(googleEventId));
+    if eventCreator is sql:NoRowsError {
+        return;
+    }
+    return eventCreator;
 }

--- a/apps/meet-app/backend/modules/database/db_functions.bal
+++ b/apps/meet-app/backend/modules/database/db_functions.bal
@@ -165,15 +165,3 @@ public isolated function getMeetingIdsByRegions(string startTime, string endTime
     return from var row in titleStream
         select row.title;
 }
-
-# Fetches event creator by google event Id.
-# 
-# + googleEventId - Google Event Id
-# + return - Creator of google event id or error, if not found
-public isolated function getEventCreatorByGoogleEventId(string googleEventId) returns string|error? {
-    string|sql:Error eventCreator = databaseClient->queryRow(creatorEmailByGoogleEventId(googleEventId));
-    if eventCreator is sql:NoRowsError {
-        return;
-    }
-    return eventCreator;
-}

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -46,6 +46,7 @@ isolated function addMeetingQuery(AddMeetingPayload meeting, string createdBy) r
         host_team,
         host_sub_team,
         host_unit,
+        event_creator,
         start_time, 
         end_time, 
         wso2_participants,
@@ -64,6 +65,7 @@ isolated function addMeetingQuery(AddMeetingPayload meeting, string createdBy) r
         ${meeting.team},
         ${meeting.subTeam},
         ${meeting.unit},
+        ${meeting.eventCreator},
         ${meeting.startTime}, 
         ${meeting.endTime}, 
         ${meeting.internalParticipants},
@@ -338,4 +340,18 @@ isolated function meetingTitlesByRegionsQuery(string startTime, string endTime, 
         start_time >= ${startTime} AND
         start_time < ${endTime} AND
         meeting_status = ${ACTIVE}
+`;
+# Build query to retrieve the event creator by google even Id.
+# 
+# + googleEventId - Google event Id
+# + return - sql:ParameterizedQuery
+isolated function creatorEmailByGoogleEventId(string googleEventId)
+    returns  sql:ParameterizedQuery=>
+`
+    SELECT
+        event_creator
+    FROM 
+        meeting
+    WHERE google_event_id = ${googleEventId}
+    LIMIT 1
 `;

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -196,6 +196,7 @@ isolated function getMeetingQuery(int meetingId) returns sql:ParameterizedQuery 
         title, 
         google_event_id AS 'googleEventId',
         host, 
+        event_creator as 'eventCreator',
         DATE_FORMAT(start_time, '%Y-%m-%d %H:%i:%s') AS 'startTime',
         DATE_FORMAT(end_time, '%Y-%m-%d %H:%i:%s') AS 'endTime',
         wso2_participants as internalParticipants, 
@@ -340,18 +341,4 @@ isolated function meetingTitlesByRegionsQuery(string startTime, string endTime, 
         start_time >= ${startTime} AND
         start_time < ${endTime} AND
         meeting_status = ${ACTIVE}
-`;
-# Build query to retrieve the event creator by google even Id.
-# 
-# + googleEventId - Google event Id
-# + return - sql:ParameterizedQuery
-isolated function creatorEmailByGoogleEventId(string googleEventId)
-    returns  sql:ParameterizedQuery=>
-`
-    SELECT
-        event_creator
-    FROM 
-        meeting
-    WHERE google_event_id = ${googleEventId}
-    LIMIT 1
 `;

--- a/apps/meet-app/backend/modules/database/types.bal
+++ b/apps/meet-app/backend/modules/database/types.bal
@@ -42,6 +42,8 @@ public type AddMeetingPayload record {|
     string googleEventId;
     # Host of the meeting
     string host;
+    # Creator of the event
+    string eventCreator;
     # Internal participants' email list
     string internalParticipants;
     # Meeting start time in ISO format

--- a/apps/meet-app/backend/modules/database/types.bal
+++ b/apps/meet-app/backend/modules/database/types.bal
@@ -76,6 +76,8 @@ public type Meeting record {|
     string googleEventId;
     # Host of the meeting
     string host;
+    # Meet creator email
+    string eventCreator;
     # Meeting start time
     string startTime;
     # Meeting end time

--- a/apps/meet-app/backend/resources/alterations.sql
+++ b/apps/meet-app/backend/resources/alterations.sql
@@ -13,3 +13,7 @@ ALTER TABLE people_ops_suite.meeting
   ADD COLUMN `host_team` VARCHAR(50) NULL DEFAULT 'N/A' AFTER `host_bu`,
   ADD COLUMN `host_sub_team` VARCHAR(50) NULL DEFAULT 'N/A' AFTER `host_team`,
   ADD COLUMN `host_unit` VARCHAR(50) NULL DEFAULT 'N/A' AFTER `host_sub_team`;
+
+-- Add Event Creator column to store the event creation calendarId
+ALTER TABLE people_ops_suite.meeting 
+ADD COLUMN `event_creator` VARCHAR(50) NOT NULL DEFAULT '' AFTER `host_unit`; 

--- a/apps/meet-app/backend/resources/alterations.sql
+++ b/apps/meet-app/backend/resources/alterations.sql
@@ -16,4 +16,4 @@ ALTER TABLE people_ops_suite.meeting
 
 -- Add Event Creator column to store the event creation calendarId
 ALTER TABLE people_ops_suite.meeting 
-ADD COLUMN `event_creator` VARCHAR(50) NOT NULL DEFAULT '' AFTER `host_unit`; 
+ADD COLUMN `event_creator` VARCHAR(50) NOT NULL DEFAULT '<ORIGINAL CREATOR>' AFTER `host_unit`; 

--- a/apps/meet-app/backend/resources/alterations.sql
+++ b/apps/meet-app/backend/resources/alterations.sql
@@ -1,19 +1,3 @@
--- Add a flag to indicate whether a meeting belongs to a recurring series
-ALTER TABLE people_ops_suite.meeting
-  ADD COLUMN is_recurring BOOLEAN NOT NULL DEFAULT 0
-  AFTER wso2_participants;
-
--- Add a column to store meeting type 
-ALTER TABLE people_ops_suite.meeting
-ADD COLUMN meeting_type VARCHAR(255) AFTER title;
-
--- Add Business Unit, Team, Unit and Sub-team columns to store the host's organizational state at the time of the meeting
-ALTER TABLE people_ops_suite.meeting
-  ADD COLUMN `host_bu` VARCHAR(50) NULL DEFAULT 'N/A' AFTER `host`,
-  ADD COLUMN `host_team` VARCHAR(50) NULL DEFAULT 'N/A' AFTER `host_bu`,
-  ADD COLUMN `host_sub_team` VARCHAR(50) NULL DEFAULT 'N/A' AFTER `host_team`,
-  ADD COLUMN `host_unit` VARCHAR(50) NULL DEFAULT 'N/A' AFTER `host_sub_team`;
-
 -- Add Event Creator column to store the event creation calendarId
 ALTER TABLE people_ops_suite.meeting 
 ADD COLUMN `event_creator` VARCHAR(50) NOT NULL DEFAULT '<ORIGINAL CREATOR>' AFTER `host_unit`; 

--- a/apps/meet-app/backend/resources/meet_database.sql
+++ b/apps/meet-app/backend/resources/meet_database.sql
@@ -11,6 +11,7 @@ CREATE TABLE meeting (
   `host_team` VARCHAR(50) NULL DEFAULT 'N/A',            -- Team of the host
   `host_sub_team` VARCHAR(50) NULL DEFAULT 'N/A',        -- Sub team of the host
   `host_unit` VARCHAR(50) NULL DEFAULT 'N/A',            -- Unit of the host
+  `event_creator` VARCHAR(50) NOT NULL DEFAULT '<ORIGINAL CREATOR>',  -- Creator of the event 
   `start_time` DATETIME NOT NULL,               -- Start time of the meeting
   `end_time` DATETIME NOT NULL,                 -- End time of the meeting
   `wso2_participants` TEXT NOT NULL,            -- List of participants (comma-separated values)

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -660,21 +660,10 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        string|error? creatorEmailResult = database:getEventCreatorByGoogleEventId(meeting.googleEventId);
-        if creatorEmailResult is error {
-            string customError = "Error occurred while fetching the event creator!";
-            log:printError(customError, creatorEmailResult);
-            return <http:InternalServerError>{body: customError};
-        }
-        if creatorEmailResult is null {
-            string customError = "Event creator not found!";
-            log:printError(customError);
-            return <http:InternalServerError>{body: customError};
-        }
 
         // Fetch the attachments of the meeting.
         gcalendar:Attachment[]|error? calendarEventAttachments = calendar:getCalendarEventAttachments(
-                meeting.googleEventId, creatorEmailResult);
+                meeting.googleEventId, meeting.eventCreator);
         if calendarEventAttachments is error {
             string customError = string `Error occurred while fetching the attachments!`;
             log:printError(customError, calendarEventAttachments);
@@ -759,21 +748,9 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        string|error? creatorEmailResult = database:getEventCreatorByGoogleEventId(meeting.googleEventId);
-        if creatorEmailResult is error {
-            string customError = "Error occurred while fetching the event creator!";
-            log:printError(customError, creatorEmailResult);
-            return <http:InternalServerError>{body: customError};
-        }
-        if creatorEmailResult is null {
-            string customError = "Event creator not found!";
-            log:printError(customError);
-            return <http:InternalServerError>{body: customError};
-        }
-
         // Delete the meeting from the calendar.
         calendar:DeleteCalendarEventResponse|error deleteCalendarEventResponse = calendar:deleteCalendarEvent(
-                meeting.googleEventId, creatorEmailResult);
+                meeting.googleEventId, meeting.eventCreator);
         if deleteCalendarEventResponse is error {
             string customError = string `Error occurred while deleting the meeting!`;
             log:printError(customError, deleteCalendarEventResponse);

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -373,11 +373,11 @@ service http:InterceptableService / on new http:Listener(9090) {
                 body: {
                     message: customError
                 }
-            }; 
+            };
         }
         // Attempt to create the meeting.
         calendar:CreateCalendarEventResponse|error calendarCreateEventResponse = calendar:createCalendarEvent(
-                createCalendarEventRequest, userInfo.email,meetResponse);
+                createCalendarEventRequest, userInfo.email, meetResponse);
         if calendarCreateEventResponse is error {
             string customError = string `Error occurred while creating the calendar event!`;
             log:printError(customError, calendarCreateEventResponse);
@@ -393,7 +393,7 @@ service http:InterceptableService / on new http:Listener(9090) {
         string rule = "";
         int[] meetingIds = [];
         if isRecurring {
-            gcalendar:Event|error masterEventResp = calendar:getCalendarEvent(calendarCreateEventResponse.id);
+            gcalendar:Event|error masterEventResp = calendar:getCalendarEvent(calendarCreateEventResponse.id, userInfo.email);
             if masterEventResp is error {
                 string customError = string `Error occurred while getting master event!`;
                 log:printError(customError, masterEventResp);
@@ -409,7 +409,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                 rule = recurrence[0];
             }
 
-            gcalendar:Event[]|error instances = calendar:getEventInstances(calendarCreateEventResponse.id);
+            gcalendar:Event[]|error instances = calendar:getEventInstances(calendarCreateEventResponse.id, userInfo.email);
             if instances is error {
                 string customError = string `Error occurred while fetching recurring instances!`;
                 log:printError(customError, instances);
@@ -477,6 +477,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                     title: originalTitle,
                     googleEventId: instance.id,
                     host: userInfo.email,
+                    eventCreator: userInfo.email,
                     internalParticipants: string:'join(", ", ...createCalendarEventRequest.internalParticipants
                             .map(internalParticipant => internalParticipant.trim())),
                     startTime: startTimeDb,
@@ -513,6 +514,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                 title: originalTitle,
                 googleEventId: calendarCreateEventResponse.id,
                 host: userInfo.email,
+                eventCreator: userInfo.email,
                 internalParticipants: string:'join(", ", ...createCalendarEventRequest.internalParticipants
                         .map(internalParticipant => internalParticipant.trim())),
                 startTime: createCalendarEventRequest.startTime
@@ -658,9 +660,21 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
+        string|error? creatorEmailResult = database:getEventCreatorByGoogleEventId(meeting.googleEventId);
+        if creatorEmailResult is error {
+            string customError = "Error occurred while fetching the event creator!";
+            log:printError(customError, creatorEmailResult);
+            return <http:InternalServerError>{body: customError};
+        }
+        if creatorEmailResult is null {
+            string customError = "Event creator not found!";
+            log:printError(customError);
+            return <http:InternalServerError>{body: customError};
+        }
+
         // Fetch the attachments of the meeting.
         gcalendar:Attachment[]|error? calendarEventAttachments = calendar:getCalendarEventAttachments(
-                meeting.googleEventId);
+                meeting.googleEventId, creatorEmailResult);
         if calendarEventAttachments is error {
             string customError = string `Error occurred while fetching the attachments!`;
             log:printError(customError, calendarEventAttachments);
@@ -745,9 +759,21 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
+        string|error? creatorEmailResult = database:getEventCreatorByGoogleEventId(meeting.googleEventId);
+        if creatorEmailResult is error {
+            string customError = "Error occurred while fetching the event creator!";
+            log:printError(customError, creatorEmailResult);
+            return <http:InternalServerError>{body: customError};
+        }
+        if creatorEmailResult is null {
+            string customError = "Event creator not found!";
+            log:printError(customError);
+            return <http:InternalServerError>{body: customError};
+        }
+
         // Delete the meeting from the calendar.
         calendar:DeleteCalendarEventResponse|error deleteCalendarEventResponse = calendar:deleteCalendarEvent(
-                meeting.googleEventId);
+                meeting.googleEventId, creatorEmailResult);
         if deleteCalendarEventResponse is error {
             string customError = string `Error occurred while deleting the meeting!`;
             log:printError(customError, deleteCalendarEventResponse);

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -365,9 +365,19 @@ service http:InterceptableService / on new http:Listener(9090) {
             meetingType = titleParts[1].trim();
             createCalendarEventRequest.title = string `${titleParts[0]} - ${titleParts[2]}`;
         }
+        string|error meetResponse = calendar:createMeet();
+        if meetResponse is error {
+            string customError = string `Error occurred while creating the meet!`;
+            log:printError(customError, meetResponse);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            }; 
+        }
         // Attempt to create the meeting.
         calendar:CreateCalendarEventResponse|error calendarCreateEventResponse = calendar:createCalendarEvent(
-                createCalendarEventRequest, userInfo.email);
+                createCalendarEventRequest, userInfo.email,meetResponse);
         if calendarCreateEventResponse is error {
             string customError = string `Error occurred while creating the calendar event!`;
             log:printError(customError, calendarCreateEventResponse);


### PR DESCRIPTION
## Overview
This PR introduces Google Meet integration into the calendar service and enhances the event creation workflow.

## Key Changes
- Added a new function to generate Google Meet links via the calendar service.
- Configured Google Meet creation to use the application admin account.
- Updated event creation to accept a pre-generated Google Meet URI.
- If a Meet URI is provided, it is attached when creating the Google Calendar event.
- Event creation now uses the logged-in user’s email.

## Summary
With this update, Google Meet links can be generated separately and seamlessly attached to calendar events, improving flexibility and aligning meeting ownership with the logged-in user.