### PR TITLE
[Meet App] feat: enable auto-recording for scheduled meetings and add standalone Meet link endpoint

### DIFF
--- a/apps/meet-app/backend/modules/calendar/calendar.bal
+++ b/apps/meet-app/backend/modules/calendar/calendar.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License. 
 import ballerina/http;
-import ballerina/uuid;
+import ballerina/url;
 import ballerinax/googleapis.calendar as gcalendar;
 
 configurable string calendarId = ?;
@@ -78,22 +78,22 @@ public isolated function createCalendarEvent(CreateCalendarEventRequest createCa
             ...createCalendarEventRequest.externalParticipants.map((email) => ({email: email.trim()}))
         ],
         guestsCanModify: true,
-        recurrence: recurrenceArray,
-        conferenceData: {
-            createRequest: {
-                requestId: uuid:createType4AsString(),
-                conferenceSolutionKey: {
-                    'type: CONFERENCE_SOLUTION_TYPE
-                }
-            }
-        },
-        meetUri: meetUri is string ? meetUri : null
+        recurrence: recurrenceArray
     };
 
     http:Request req = new;
     json calendarEventPayloadJson = calendarEventPayload.toJson();
     req.setPayload(calendarEventPayloadJson);
-    http:Response response = check calendarClient->post(string `/events/${creatorEmail}?sendUpdates=all`, req);
+
+    // Attach the pre-created (recording-enabled) Meet space to the event via the `meetUri` query
+    // parameter, so the calendar service reuses that space instead of minting a new, non-recording
+    // conference. Passing meetUri in the request body has no effect — the service reads the query.
+    string eventPath = string `/events/${creatorEmail}?sendUpdates=all`;
+    if meetUri is string {
+        string encodedMeetUri = check url:encode(meetUri, "UTF-8");
+        eventPath = string `${eventPath}&meetUri=${encodedMeetUri}`;
+    }
+    http:Response response = check calendarClient->post(eventPath, req);
 
     if response.statusCode == 201 {
         json responseJson = check response.getJsonPayload();

--- a/apps/meet-app/backend/modules/calendar/meet.bal
+++ b/apps/meet-app/backend/modules/calendar/meet.bal
@@ -16,15 +16,17 @@
 import ballerina/http;
 
 # Create a meet
-# 
+#
 # + return - Meet Uri
 public isolated function createMeet() returns error|string {
-    http:Response meetResponse = check calendarClient->post(string `/meet/${calendarId}`, {});
+    http:Response meetResponse = check calendarClient->post(string `/meet/${calendarId}?recordingEnabled=true`, {});
     if meetResponse.statusCode === 201 {
-    json meetJsonPayload = check meetResponse.getJsonPayload();
-    string extractedMeetUri = check meetJsonPayload.id;
-    return extractedMeetUri;
+        json meetJsonPayload = check meetResponse.getJsonPayload();
+        string extractedMeetUri = check meetJsonPayload.id;
+        
+        return extractedMeetUri;
     }
-    json? errorResponseBody = check meetResponse.getJsonPayload();
-    return error(string `Status: ${meetResponse.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
+    // Read the error body as text — gateway/auth faults are often not JSON.
+    string errorResponseBody = check meetResponse.getTextPayload();
+    return error(string `Status: ${meetResponse.statusCode}, Response: ${errorResponseBody}`);
 }

--- a/apps/meet-app/backend/modules/calendar/types.bal
+++ b/apps/meet-app/backend/modules/calendar/types.bal
@@ -92,17 +92,6 @@ public type CreateCalendarEventPayload record {|
     boolean guestsCanModify;
     # Recurrence rules
     string[]? recurrence?;
-    # Event conference data
-    record {|
-        record {|
-            string requestId;
-            record {|
-                string 'type;
-            |} conferenceSolutionKey;
-        |} createRequest;
-    |} conferenceData;
-    # Meet Uri
-    string? meetUri = ();
 |};
 
 # Event create success response record.

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -324,6 +324,24 @@ service http:InterceptableService / on new http:Listener(9090) {
         return meetingTypes;
     }
 
+    # Mint a standalone Google Meet link via the calendar-event-service.
+    # Used by the Google Calendar conferencing add-on.
+    #
+    # + return - The Meet link | Error
+    resource function post meet() returns MeetLinkResponse|http:InternalServerError {
+        string|error meetUri = calendar:createMeet();
+        if meetUri is error {
+            string customError = "Error occurred while creating the meet!";
+            log:printError(customError, meetUri);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+        return {id: meetUri};
+    }
+
     # Create a new meeting.
     #
     # + createCalendarEventRequest - Create calendar event request

--- a/apps/meet-app/backend/types.bal
+++ b/apps/meet-app/backend/types.bal
@@ -75,6 +75,12 @@ public type MeetingCreationResponse record {|
     int meetingId;
 |};
 
+# Represents the response after minting a standalone Google Meet link.
+public type MeetLinkResponse record {|
+    # Google Meet join URL returned by the calendar-event-service
+    string id;
+|};
+
 # Represents the response when retrieving a list of meetings.
 public type MeetingListResponse record {|
     # Meeting count


### PR DESCRIPTION
## Purpose
Meetings scheduled through Meet App were **not being recorded**, and there was no backend endpoint to mint a standalone Google Meet link for the Google Calendar conferencing add-on.

- Meetings created via the app produced a Meet link with recording disabled, so no recording was ever generated for sales meetings.
- A second, unintended Meet conference was being minted on the calendar event (via `conferenceData.createRequest`), so even the link users joined was not the recording-enabled one.


## Goals
- Enable auto-recording for every meeting scheduled through Meet App.
- Ensure the Meet link attached to the calendar event **is** the recording-enabled space (one meeting, not two).
- Expose a `POST /meet` endpoint that returns a standalone Meet link for the conferencing add-on.

## Approach
- `calendar:createMeet()` now requests a recording-enabled space from the calendar-event-service via `?recordingEnabled=true`, which sets`autoRecordingGeneration: ON` on the Meet space.
- Instead of asking Google to create a new conference on the event, the pre-created recording space is attached by passing its URI as the `meetUri` **query parameter**; the calendar-event-service then writes that URI into the event' `conferenceData`. Removed the now-unused `conferenceData.createRequest`  and `meetUri` fields from the event payload type.
- Added a `POST /meet` resource returning a new `MeetLinkResponse` record, backed by the existing `calendar:createMeet()`.

No UI changes.

## User stories
- As a sales team member, when I schedule a meeting through Meet App, it should be recorded automatically so the session is captured without manual steps.
- As the Google Calendar conferencing add-on, I need an endpoint that mints a standalone Meet link so I can attach it to an event.

## Release note
Meetings scheduled through Meet App are now created with auto-recording enabled and a new `POST /meet` endpoint mints standalone Google Meet links.

## Documentation
N/A — internal backend integration change with no user-facing product docs impact.

## Training
N/A — no training-content impact.

## Certification
N/A 
## Marketing
N/A.

## Automation tests
 - Unit tests
   > No new unit tests added in this PR; the change is verified against the live  calendar-event-service. 
 - Integration tests
   > Manually verified end-to-end: created a meeting, confirmed a single
   > recording-enabled Meet link on the event, and confirmed the space records on
   > join. No automated integration tests added.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes — the `meetUri` value is URL-encoded before use; no user input is string-concatenated into queries.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — only `.bal` source is committed; `config.toml` (which holds credentials) is git-ignored and not part of this PR.

## Samples
N/A.

## Related PRs
- calendar-event-service change that added `recordingEnabled` support to `POST /meet`(`wso2-enterprise/digiops-hr`, ⟨PR #1794 — verify⟩) — this PR depends on it.

## Migrations (if applicable)
N/A — no database schema or data migrations in this change.

## Test environment
- OS: macOS (Darwin 25.5)
- Ballerina: Swan Lake ⟨2201.13.4 — confirm⟩
- Backend dependency: MySQL (local) + calendar-event-service on apis-stg
- JDK: bundled with the Ballerina distribution
- Browser: N/A (backend-only change)

## Learning
- Google Meet REST API v2 `spaces` — `config.artifactConfig.recordingConfig.autoRecordingGeneration`.
- Google Calendar API `conferenceData`: attaching an existing meeting via `entryPoints` + `hangoutsMeet` solution vs. minting a new one with`createRequest`, and the `conferenceDataVersion` flag.
- The calendar-event-service contract (`meetUri` / `recordingEnabled` query params on `POST /events` and `POST /meet`).
