### PR TITLE
feat: create meetings on the shared scheduling calendar so recording

### DIFF
--- a/apps/meet-app/backend/modules/calendar/calendar.bal
+++ b/apps/meet-app/backend/modules/calendar/calendar.bal
@@ -20,10 +20,25 @@ import ballerinax/googleapis.calendar as gcalendar;
 configurable string calendarId = ?;
 configurable string disclaimerMessage = ?;
 
-# Create an event in the calendar.
+# Get the shared scheduling account's calendar id.
+#
+# The event is created on this account so it is the event organizer, which is the account whose Drive
+# receives the Meet recording (recordings follow the calendar event organizer). The logged-in user and
+# participants are added as attendees with edit rights.
+#
+# + return - The shared scheduling calendar id
+public isolated function getSchedulingCalendarId() returns string => calendarId;
+
+# Create an event on the shared scheduling calendar.
+#
+# The event is created on the shared account (`calendarId`) so the shared account is the organizer and
+# the Meet recording lands in the shared account's Drive. The logged-in user (`creatorEmail`) and the
+# participants are added as attendees and, together with `guestsCanModify`, can edit the event
+# (time, location, etc.). Guests cannot change the organizer, so the recording stays with the shared
+# account.
 #
 # + createCalendarEventRequest - Create calendar event request
-# + creatorEmail - Event creator Email
+# + creatorEmail - Logged-in user's email (added as an attendee and shown in the disclaimer)
 # + meetUri - Meet URL
 # + return - JSON response if successful, else an error
 public isolated function createCalendarEvent(CreateCalendarEventRequest createCalendarEventRequest,
@@ -93,7 +108,10 @@ public isolated function createCalendarEvent(CreateCalendarEventRequest createCa
     http:Request req = new;
     json calendarEventPayloadJson = calendarEventPayload.toJson();
     req.setPayload(calendarEventPayloadJson);
-    http:Response response = check calendarClient->post(string `/events/${creatorEmail}?sendUpdates=all`, req);
+    // Create the event on the shared scheduling calendar so the shared account is the organizer
+    // (and thus owns the Meet recording). The logged-in user and participants are attendees with
+    // edit rights via guestsCanModify.
+    http:Response response = check calendarClient->post(string `/events/${calendarId}?sendUpdates=all`, req);
 
     if response.statusCode == 201 {
         json responseJson = check response.getJsonPayload();

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -358,6 +358,10 @@ service http:InterceptableService / on new http:Listener(9090) {
         string subTeam = employee.subTeam ?: "N/A";
         string businessUnit = employee.businessUnit ?: "N/A";
 
+        // Shared scheduling account: the event is created on this calendar so it is the organizer
+        // and the Meet recording lands in its Drive. Read-backs and DB records target it too.
+        string schedulingCalendarId = calendar:getSchedulingCalendarId();
+
         string originalTitle = createCalendarEventRequest.title;
         string meetingType = "General";
         string[] titleParts = re `-`.split(createCalendarEventRequest.title);
@@ -393,7 +397,7 @@ service http:InterceptableService / on new http:Listener(9090) {
         string rule = "";
         int[] meetingIds = [];
         if isRecurring {
-            gcalendar:Event|error masterEventResp = calendar:getCalendarEvent(calendarCreateEventResponse.id, userInfo.email);
+            gcalendar:Event|error masterEventResp = calendar:getCalendarEvent(calendarCreateEventResponse.id, schedulingCalendarId);
             if masterEventResp is error {
                 string customError = string `Error occurred while getting master event!`;
                 log:printError(customError, masterEventResp);
@@ -409,7 +413,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                 rule = recurrence[0];
             }
 
-            gcalendar:Event[]|error instances = calendar:getEventInstances(calendarCreateEventResponse.id, userInfo.email);
+            gcalendar:Event[]|error instances = calendar:getEventInstances(calendarCreateEventResponse.id, schedulingCalendarId);
             if instances is error {
                 string customError = string `Error occurred while fetching recurring instances!`;
                 log:printError(customError, instances);
@@ -477,7 +481,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                     title: originalTitle,
                     googleEventId: instance.id,
                     host: userInfo.email,
-                    eventCreator: userInfo.email,
+                    eventCreator: schedulingCalendarId,
                     internalParticipants: string:'join(", ", ...createCalendarEventRequest.internalParticipants
                             .map(internalParticipant => internalParticipant.trim())),
                     startTime: startTimeDb,
@@ -514,7 +518,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                 title: originalTitle,
                 googleEventId: calendarCreateEventResponse.id,
                 host: userInfo.email,
-                eventCreator: userInfo.email,
+                eventCreator: schedulingCalendarId,
                 internalParticipants: string:'join(", ", ...createCalendarEventRequest.internalParticipants
                         .map(internalParticipant => internalParticipant.trim())),
                 startTime: createCalendarEventRequest.startTime


### PR DESCRIPTION
### Purpose

> Meet recordings were saving to the logged-in user's Drive instead of the shared scheduling account's, because the recording follows the calendar event organizer, and the event was created on the user's calendar.

### Goals

> Store recordings in the shared account's Drive, while keeping edit access for the scheduler and participants.


### Approach

> Create the event on the shared account's calendar (/events/${calendarId}) so it's the organizer; add the user + participants as attendees with guestsCanModify. Read-backs and stored eventCreator now target the shared calendar. Backend-only; no calendar-event-service changes.


### User stories

> As a scheduler, my meeting's recording is owned centrally by the shared account, and I can still edit the event.


### Release note

> Meeting recordings are now stored in and attached to the shared scheduling account's Drive instead of the scheduler's personal Drive.

### Documentation

> N/A — internal behavior change, no product docs affected.


### Training

> N/A


### Certification

> N/A 


### Marketing

> N/A


### Automation tests

> Unit tests
> No new unit tests; existing backend/tests/ remain valid


### Integration tests

> Manually verified end-to-end on staging: shared account is organizer, recording saves to + attaches on its Drive, edit and cancel work.

### Security checks

> Followed secure coding standards? yes
> Confirmed no keys/passwords/tokens/secrets committed? yes (diff audited; local CORS/localhost excluded)

### Samples

> N/A


### Related PRs

> N/A


### Migrations (if applicable)

> None. 


### Test environment

> Ballerina 2201.13.4; macOS + staging calendar-event-service; MySQL. Backend-only (no browser).


### Learning

> Recording ownership follows the calendar event organizer (not the Meet space creator) for event-attached spaces. events.move rejected — it doesn't move the recording and detaches the link.