### PR TITLE
[Meet App] feat: update distribution version to 2201.13.4

### DIFF
--- a/apps/meet-app/backend/Ballerina.toml
+++ b/apps/meet-app/backend/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "wso2"
 name = "meet_app"
 version = "1.0.0"
-distribution = "2201.8.4"
+distribution = "2201.13.4"
 
 [build-options]
 observabilityIncluded = true


### PR DESCRIPTION
This pull request updates the Ballerina distribution version used by the backend of the meet app. The change ensures compatibility with newer features and bug fixes provided in Ballerina.

- Dependency update:
  * Upgraded the `distribution` version in `Ballerina.toml` from `2201.8.4` to `2201.13.4` to use the latest Ballerina runtime.

Fixes: https://github.com/wso2-enterprise/digiops-sales/issues/1552