### PR TITLE
[Meet App] Fix: restore deprecated drive module apis and db changes

### DIFF
--- a/apps/meet-app/backend/config.toml.local
+++ b/apps/meet-app/backend/config.toml.local
@@ -11,24 +11,31 @@
         clientSecret = ""
 
     [meet_app.calendar.retryConfig]
-        count = 
-        interval = 
-        backOffFactor = 
+        count =
+        interval =
+        backOffFactor =
         maxWaitInterval =
 
 [meet_app.people]
     hrEntityBaseUrl = ""
     allowedEmploymentTypes = []
+    # Optional. Departments whose members auto-get view access to recordings.
+    # Defaults to the three below if omitted.
+    recordingAccessDepartments = ["SALES", "CHANNEL SALES", "SALES ENGINEERING"]
+    # Optional. For staging: if non-empty, recordings are shared only with these test
+    # emails instead of the real departments above. Leave empty ([]) in production.
+    recordingAccessTestEmails = []
+
     [meet_app.people.oauthConfig]
         tokenUrl = ""
         clientId = ""
         clientSecret = ""
 
     [meet_app.people.retryConfig]
-        count = 
-        interval = 
-        backOffFactor = 
-        maxWaitInterval = 
+        count =
+        interval =
+        backOffFactor =
+        maxWaitInterval =
 
 [meet_app.sales]
     salesEntityBaseUrl = ""
@@ -38,11 +45,12 @@
         clientSecret = ""
 
     [meet_app.sales.retryConfig]
-        count = 
-        interval = 
-        backOffFactor = 
-        maxWaitInterval = 
+        count =
+        interval =
+        backOffFactor =
+        maxWaitInterval =
 
+# Old scheduling flow's direct Google Drive client (attach permissions + recording counts).
 [meet_app.drive]
     driveBaseUrl = ""
     [meet_app.drive.oauthConfig]
@@ -52,23 +60,37 @@
         refreshToken = ""
 
     [meet_app.drive.retryConfig]
-        count = 
-        interval = 
-        backOffFactor = 
-        maxWaitInterval = 
+        count =
+        interval =
+        backOffFactor =
+        maxWaitInterval =
+
+# New auto-recording flow: talks to the drive-service (Go) via Asgardeo M2M, not Google directly.
+[meet_app.driveservice]
+    driveServiceBaseUrl = ""
+    [meet_app.driveservice.oauthConfig]
+        tokenUrl = ""
+        clientId = ""
+        clientSecret = ""
+
+    [meet_app.driveservice.retryConfig]
+        count =
+        interval =
+        backOffFactor =
+        maxWaitInterval =
 
 [meet_app.database.dbConfig]
     host = ""
     user = ""
     password = ""
     database = ""
-    port = 
+    port =
     [meet_app.database.dbConfig.connectionPool]
-    maxOpenConnections = 
-    maxConnectionLifeTime = 
-    minIdleConnections= 
+    maxOpenConnections =
+    maxConnectionLifeTime =
+    minIdleConnections=
     [meet_app.database.dbConfig.options]
-    connectTimeout = 
+    connectTimeout =
 
 [meet_app.authorization.authorizedRoles]
     SALES_TEAM  = ""
@@ -89,3 +111,17 @@
 [meet_app.salesDesignations]
  teamNameOfAccountManager = ""
  teamNameOfTechnicalOfficer = ""
+
+# Calendar-watch + auto-recording listeners and the watch-channel renewal job.
+[meet_app]
+    # Ports the two extra listeners bind to (defaults shown; override only if needed).
+    calendarWatchListenerPort = 9093
+    meetEventsListenerPort = 9091
+    # The Shared Account whose calendar is watched for add-on meetings.
+    sharedAccountEmail = ""
+    # Shared secret Google echoes back on every watch ping (pick any value).
+    calendarWatchToken = ""
+    # Public URL of THIS service's calendar-watch (9093) endpoint that Google pings.
+    calendarWatchWebhookUrl = ""
+    # Any stable prefix used when naming watch channels.
+    calendarWatchChannelIdPrefix = ""

--- a/apps/meet-app/backend/modules/drive/Module.md
+++ b/apps/meet-app/backend/modules/drive/Module.md
@@ -1,0 +1,3 @@
+# Module Overview
+
+Contains google-drive related functions, types and constants.

--- a/apps/meet-app/backend/modules/drive/client.bal
+++ b/apps/meet-app/backend/modules/drive/client.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/http;
+
+configurable string driveBaseUrl = ?;
+configurable DriveRetryConfig retryConfig = ?;
+configurable Oauth2Config oauthConfig = ?;
+
+final http:Client driveClient = check new (driveBaseUrl, {
+    auth: {
+        ...oauthConfig
+    },
+    httpVersion: http:HTTP_1_1,
+    http1Settings: {keepAlive: http:KEEPALIVE_NEVER},
+    retryConfig: {
+        ...retryConfig
+    }
+});

--- a/apps/meet-app/backend/modules/drive/constants.bal
+++ b/apps/meet-app/backend/modules/drive/constants.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License. 
+
+# client retry configuration for max retry attempts.
+public const int RETRY_COUNT = 3;
+
+# client retry configuration for wait interval in seconds.
+public const decimal RETRY_INTERVAL = 3.0;
+
+# client retry configuration for interval increment in seconds.
+public const float RETRY_BACKOFF_FACTOR = 2.0;
+
+# client retry configuration for maximum wait interval in seconds.
+public const decimal RETRY_MAX_INTERVAL = 20.0;

--- a/apps/meet-app/backend/modules/drive/drive.bal
+++ b/apps/meet-app/backend/modules/drive/drive.bal
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License. 
+import meet_app.database;
+import ballerina/http;
+import ballerina/url;
+
+# Sets file permission for a user on Google Drive.
+#
+# + fileId - Google Drive file ID.
+# + role - The permission role to assign.
+# + 'type - The type of the permission.
+# + emailAddress - The email of the user to whom the permission will be granted.
+# + return - JSON response if successful, else an error
+public isolated function setFilePermission(string fileId, DrivePermissionRole role, DrivePermissionType 'type,
+        string emailAddress) returns DrivePermissionResponse|error {
+
+    DrivePermissionPayload drivePermissionPayload = {
+        role,
+        'type,
+        emailAddress
+    };
+
+    http:Request req = new;
+    json drivePermissionPayloadJson = drivePermissionPayload.toJson();
+    req.setPayload(drivePermissionPayloadJson);
+    http:Response response = check driveClient->post(string `/${fileId}/permissions`, req);
+
+    if response.statusCode == 200 {
+        json responseJson = check response.getJsonPayload();
+        DrivePermissionResponse drivePermissionResponse = check responseJson.cloneWithType(DrivePermissionResponse);
+        return drivePermissionResponse;
+    }
+
+    json? errorResponseBody = check response.getJsonPayload();
+    return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
+}
+
+# Counts WSO2 recordings within a specific date range.
+#
+# + startTime - ISO string for start of period
+# + endTime - ISO string for end of period
+# + region - Region filter
+# + return - Count of files or error
+public isolated function countWso2RecordingsInDateRange(string startTime, string endTime, string? region) returns int|error {
+    string[] titlesToMatch = [];
+    if region is string {
+        titlesToMatch = check database:getMeetingIdsByRegions(startTime, endTime, region);
+        if titlesToMatch.length() == 0 {
+            return 0;
+        }
+    }
+    string driveQuery = string `name contains 'WSO2' and 'me' in owners and mimeType = 'video/mp4' and trashed = false and createdTime >= '${startTime}' and createdTime < '${endTime}'`;
+    string encodedQuery = check url:encode(driveQuery, "UTF-8");
+
+    int totalCount = 0;
+    string? pageToken = ();
+    boolean hasMorePages = true;
+
+    while (hasMorePages) {
+        string path = string `?q=${encodedQuery}&fields=files(id,name),nextPageToken&pageSize=1000${
+            pageToken is string ? "&pageToken=" + pageToken : ""}`;
+        http:Response response = check driveClient->get(path);
+        if response.statusCode == 200 {
+            json payload = check response.getJsonPayload();
+            DriveSearchResponse searchResponse = check payload.cloneWithType(DriveSearchResponse);
+
+            if region is string {
+                foreach var file in searchResponse.files {
+                    string fileName = file.name;
+                    boolean isMatch = false;
+                    foreach string title in titlesToMatch {
+                        if fileName.includes(title) {
+                            isMatch = true;
+                            break;
+                        }
+                    }
+                    if isMatch {
+                        totalCount += 1;
+                    }
+                }
+            } else {
+                totalCount += searchResponse.files.length();
+            }
+            pageToken = searchResponse.nextPageToken;
+            hasMorePages = pageToken is string;
+        } else {
+            return error(string `Drive API Error: ${response.statusCode}`,
+                        body = check response.getJsonPayload());
+        }
+    }
+
+    return totalCount;
+}

--- a/apps/meet-app/backend/modules/drive/types.bal
+++ b/apps/meet-app/backend/modules/drive/types.bal
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License. 
+
+# [Configurable] OAuth2 entity application configuration.
+type Oauth2Config record {|
+    # OAuth2 refresh URL
+    string refreshUrl;
+    # OAuth2 refresh token
+    string refreshToken;
+    # OAuth2 client ID
+    string clientId;
+    # OAuth2 client secret
+    string clientSecret;
+|};
+
+# Retry config for the calendar client.
+public type DriveRetryConfig record {|
+    # Retry count
+    int count = RETRY_COUNT;
+    # Retry interval
+    decimal interval = RETRY_INTERVAL;
+    # Retry backOff factor
+    float backOffFactor = RETRY_BACKOFF_FACTOR;
+    # Retry max interval
+    decimal maxWaitInterval = RETRY_MAX_INTERVAL;
+|};
+
+# Drive permission payload.
+public type DrivePermissionPayload record {|
+    # Role of the permission
+    DrivePermissionRole role;
+    # Type of the permission
+    DrivePermissionType 'type;
+    # Email address of the user
+    string emailAddress?;
+|};
+
+# Drive permission response.
+public type DrivePermissionResponse record {|
+    # Role assigned
+    DrivePermissionRole role;
+    # Kind of the resource (always "drive#permission")
+    string kind;
+    # Type of the permission
+    DrivePermissionType 'type;
+    # Unique ID of the permission
+    string id;
+|};
+
+# DrivePermissionRole enum.
+public enum DrivePermissionRole {
+    OWNER = "owner",
+    EDITOR = "writer",
+    COMMENTER = "commenter",
+    VIEWER = "reader"
+};
+
+# DrivePermissionType enum.
+public enum DrivePermissionType {
+    USER = "user",
+    GROUP = "group",
+    DOMAIN = "domain",
+    ANYONE = "anyone"
+}
+
+# Represents a single file object from Drive.
+public type DriveFile record {|
+    # Unique ID of the file
+    string id;
+    # Name of the file
+    string name;
+|};
+
+# Drive search response.
+public type DriveSearchResponse record {|
+    # List of files found
+    DriveFile[] files;
+    # Token for the next page of results (if any)
+    string nextPageToken?;
+|};

--- a/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
+++ b/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
@@ -1,16 +1,15 @@
 USE people_ops_suite;
+-- New columns for the auto-recorded meetings flow. The original scheduling columns
+-- (meeting_type, host_bu/team/sub_team/unit, is_recurring) are deliberately kept so the
+-- existing meet-app scheduling functionality keeps working alongside this. The
+-- auto-recording INSERT (upsertMeetRecordingQuery) doesn't set those columns, which is fine:
+-- host_* / is_recurring have defaults, and meeting_type is nullable (see the staging
+-- remediation note below), so auto-recorded rows simply leave them empty.
 ALTER TABLE meeting
     ADD COLUMN space_name VARCHAR(255) NULL,
     ADD COLUMN external_participants TEXT NULL,
     ADD COLUMN drive_file_id VARCHAR(255) NULL,
     ADD COLUMN recording_state ENUM('PENDING', 'ATTACHED', 'FAILED') NULL;
-ALTER TABLE meeting
-    DROP COLUMN meeting_type,
-    DROP COLUMN host_bu,
-    DROP COLUMN host_team,
-    DROP COLUMN host_sub_team,
-    DROP COLUMN host_unit,
-    DROP COLUMN is_recurring;
 CREATE TABLE calendar_watch_state (
     id INT PRIMARY KEY DEFAULT 1,
     sync_token VARCHAR(1000) NULL,
@@ -24,3 +23,23 @@ INSERT INTO calendar_watch_state (id, sync_token) VALUES (1, NULL);
 -- Prevents two concurrent upsertMeetRecording calls from ever creating duplicate rows for
 -- the same Meet space; paired with an atomic INSERT ... ON DUPLICATE KEY UPDATE in code.
 ALTER TABLE meeting ADD UNIQUE (space_name);
+
+-- ── STAGING REMEDIATION (one-off, run manually) ──────────────────────────────────
+-- ONLY for an environment where an earlier version of this migration already ran its
+-- (now-removed) "DROP COLUMN meeting_type, host_bu, host_team, host_sub_team, host_unit,
+-- is_recurring" block and therefore lost those columns (e.g. staging). This re-adds them so
+-- the existing meeting-scheduling functionality works again.
+--   * meeting_type is re-added as NULL (it was originally NOT NULL) so the auto-recording
+--     INSERT -- which never sets meeting_type -- doesn't fail. The stats query already filters
+--     `WHERE meeting_type IS NOT NULL`, so auto-recorded rows are correctly excluded.
+--   * host_* / is_recurring are re-added with their original defaults.
+-- Do NOT run this on a fresh DB built from meet_database.sql -- it already has these columns
+-- and this block would error on duplicate columns. Uncomment and run only where needed:
+--
+-- ALTER TABLE meeting
+--     ADD COLUMN meeting_type  VARCHAR(255) NULL,
+--     ADD COLUMN host_bu       VARCHAR(50)  NULL DEFAULT 'N/A',
+--     ADD COLUMN host_team     VARCHAR(50)  NULL DEFAULT 'N/A',
+--     ADD COLUMN host_sub_team VARCHAR(50)  NULL DEFAULT 'N/A',
+--     ADD COLUMN host_unit     VARCHAR(50)  NULL DEFAULT 'N/A',
+--     ADD COLUMN is_recurring  BOOLEAN      NOT NULL DEFAULT 0;

--- a/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
+++ b/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
@@ -3,13 +3,21 @@ USE people_ops_suite;
 -- (meeting_type, host_bu/team/sub_team/unit, is_recurring) are deliberately kept so the
 -- existing meet-app scheduling functionality keeps working alongside this. The
 -- auto-recording INSERT (upsertMeetRecordingQuery) doesn't set those columns, which is fine:
--- host_* / is_recurring have defaults, and meeting_type is nullable (see the staging
--- remediation note below), so auto-recorded rows simply leave them empty.
+-- host_* / is_recurring have defaults, and meeting_type is made nullable just below, so
+-- auto-recorded rows simply leave them empty.
 ALTER TABLE meeting
     ADD COLUMN space_name VARCHAR(255) NULL,
     ADD COLUMN external_participants TEXT NULL,
     ADD COLUMN drive_file_id VARCHAR(255) NULL,
     ADD COLUMN recording_state ENUM('PENDING', 'ATTACHED', 'FAILED') NULL;
+
+-- meeting_type was originally NOT NULL, but the auto-recording INSERT never sets it, so it
+-- must allow NULL. Safe no-op if already nullable. Run this on any environment where the
+-- meeting_type column still EXISTS (e.g. production upgrading from the original schema).
+-- On an environment that DROPPED meeting_type (see staging remediation below), skip this --
+-- the remediation re-adds it already nullable. The stats query filters `meeting_type IS NOT
+-- NULL`, so auto-recorded rows (NULL type) stay correctly excluded from the type breakdown.
+ALTER TABLE meeting MODIFY meeting_type VARCHAR(255) NULL;
 CREATE TABLE calendar_watch_state (
     id INT PRIMARY KEY DEFAULT 1,
     sync_token VARCHAR(1000) NULL,

--- a/apps/meet-app/backend/resources/meet_database.sql
+++ b/apps/meet-app/backend/resources/meet_database.sql
@@ -4,7 +4,7 @@ USE `people_ops_suite`;
 CREATE TABLE meeting (
   `meeting_id` INT NOT NULL AUTO_INCREMENT,    -- Unique meeting ID
   `title` VARCHAR(120) NOT NULL,                -- Title of the meeting
-  `meeting_type` VARCHAR(255) NOT NULL,         -- Type of the meeting
+  `meeting_type` VARCHAR(255) NULL,             -- Type of the meeting (nullable: auto-recorded rows have none)
   `google_event_id` VARCHAR(120) NOT NULL,      -- Google event ID
   `host` VARCHAR(60) NOT NULL,                  -- Host of the meeting
   `host_bu` VARCHAR(50) NULL DEFAULT 'N/A',              -- Business unit of the host

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -674,8 +674,8 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        // Update editor permissions for all available video/mp4 attachments of the meeting.
-       
+        return {attachments: calendarEventAttachments ?: []};
+    }
 
     # Delete meeting.
     #
@@ -790,7 +790,6 @@ service http:InterceptableService / on new http:Listener(9090) {
 
         time:Civil startCivil = time:utcToCivil(startUtc);
         time:Civil endCivil = time:utcToCivil(endUtc);
-        map<future<int|error>> driveFutureMap = {};
         map<json> metaDataMap = {};
 
         int cursorYear = startCivil.year;
@@ -802,25 +801,12 @@ service http:InterceptableService / on new http:Listener(9090) {
             }
             string monthStr = cursorMonth < 10 ? string `0${cursorMonth}` : cursorMonth.toString();
             string monthKey = string `${cursorYear}-${monthStr}`;
-            string queryStartTime = string `${cursorYear}-${monthStr}-01T00:00:00Z`;
-            int nextMonthVal = cursorMonth + 1;
-            int nextYearVal = cursorYear;
 
-            if (nextMonthVal > 12) {
-                nextMonthVal = 1;
-                nextYearVal = nextYearVal + 1;
-            }
-            string nextMonthStr = nextMonthVal < 10 ? string `0${nextMonthVal}` : nextMonthVal.toString();
-            string queryEndTime = string `${nextYearVal}-${nextMonthStr}-01T00:00:00Z`;
-
-            if (cursorYear == startCivil.year && cursorMonth == startCivil.month) {
-                queryStartTime = startDate;
-            }
-            if (cursorYear == endCivil.year && cursorMonth == endCivil.month) {
-                queryEndTime = endDate;
-            }
-
-           
+            metaDataMap[monthKey] = {
+                "year": cursorYear,
+                "month": cursorMonth,
+                "key": monthKey
+            };
 
             cursorMonth = cursorMonth + 1;
             if cursorMonth > 12 {
@@ -830,23 +816,19 @@ service http:InterceptableService / on new http:Listener(9090) {
         }
 
         map<int> dbCounts = check wait scheduledCounts;
-        map<int|error> driveResults = {};
-
-        foreach string key in driveFutureMap.keys() {
-            driveResults[key] = wait driveFutureMap.get(key);
-        }
         json[] monthlyStats = [];
-        string[] sortedKeys = driveFutureMap.keys().sort(array:DESCENDING);
+        string[] sortedKeys = metaDataMap.keys().sort(array:DESCENDING);
 
         foreach string key in sortedKeys {
             json meta = metaDataMap.get(key);
-            // Drive Count
-            int|error? driveCount = driveResults[key];
             // DB Count
             int scheduledCount = dbCounts.hasKey(key) ? dbCounts.get(key) : 0;
 
+            // recordingCount used to come from the old Drive API's
+            // countWso2RecordingsInDateRange, which is gone now along with that dead client --
+            // kept as a static 0 so the response shape doesn't change for existing consumers.
             _ = check meta.mergeJson({
-                "recordingCount": (driveCount is int) ? driveCount : 0,
+                "recordingCount": 0,
                 "scheduledCount": scheduledCount
             });
             monthlyStats.push(meta);

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -16,6 +16,7 @@
 import meet_app.authorization;
 import meet_app.calendar;
 import meet_app.database;
+import meet_app.drive;
 import meet_app.people;
 import meet_app.sales;
 
@@ -674,6 +675,20 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
+        // Update editor permissions for all available video/mp4 attachments of the meeting.
+        foreach gcalendar:Attachment attachment in calendarEventAttachments ?: [] {
+            if attachment.mimeType == "video/mp4" {
+                drive:DrivePermissionResponse|error permissionResult = drive:setFilePermission(
+                        <string>attachment.fileId, drive:EDITOR, drive:USER, meeting.host
+                );
+
+                if permissionResult is error {
+                    string customError = string `Failed to update Editor permission for the host!`;
+                    log:printError(customError, permissionResult);
+                }
+            }
+        }
+
         return {attachments: calendarEventAttachments ?: []};
     }
 
@@ -790,6 +805,7 @@ service http:InterceptableService / on new http:Listener(9090) {
 
         time:Civil startCivil = time:utcToCivil(startUtc);
         time:Civil endCivil = time:utcToCivil(endUtc);
+        map<future<int|error>> driveFutureMap = {};
         map<json> metaDataMap = {};
 
         int cursorYear = startCivil.year;
@@ -801,7 +817,27 @@ service http:InterceptableService / on new http:Listener(9090) {
             }
             string monthStr = cursorMonth < 10 ? string `0${cursorMonth}` : cursorMonth.toString();
             string monthKey = string `${cursorYear}-${monthStr}`;
+            string queryStartTime = string `${cursorYear}-${monthStr}-01T00:00:00Z`;
+            int nextMonthVal = cursorMonth + 1;
+            int nextYearVal = cursorYear;
 
+            if (nextMonthVal > 12) {
+                nextMonthVal = 1;
+                nextYearVal = nextYearVal + 1;
+            }
+            string nextMonthStr = nextMonthVal < 10 ? string `0${nextMonthVal}` : nextMonthVal.toString();
+            string queryEndTime = string `${nextYearVal}-${nextMonthStr}-01T00:00:00Z`;
+
+            if (cursorYear == startCivil.year && cursorMonth == startCivil.month) {
+                queryStartTime = startDate;
+            }
+            if (cursorYear == endCivil.year && cursorMonth == endCivil.month) {
+                queryEndTime = endDate;
+            }
+
+            // Drive API
+            future<int|error> fDrive = start drive:countWso2RecordingsInDateRange(queryStartTime, queryEndTime, region);
+            driveFutureMap[monthKey] = fDrive;
             metaDataMap[monthKey] = {
                 "year": cursorYear,
                 "month": cursorMonth,
@@ -816,19 +852,23 @@ service http:InterceptableService / on new http:Listener(9090) {
         }
 
         map<int> dbCounts = check wait scheduledCounts;
+        map<int|error> driveResults = {};
+
+        foreach string key in driveFutureMap.keys() {
+            driveResults[key] = wait driveFutureMap.get(key);
+        }
         json[] monthlyStats = [];
-        string[] sortedKeys = metaDataMap.keys().sort(array:DESCENDING);
+        string[] sortedKeys = driveFutureMap.keys().sort(array:DESCENDING);
 
         foreach string key in sortedKeys {
             json meta = metaDataMap.get(key);
+            // Drive Count
+            int|error? driveCount = driveResults[key];
             // DB Count
             int scheduledCount = dbCounts.hasKey(key) ? dbCounts.get(key) : 0;
 
-            // recordingCount used to come from the old Drive API's
-            // countWso2RecordingsInDateRange, which is gone now along with that dead client --
-            // kept as a static 0 so the response shape doesn't change for existing consumers.
             _ = check meta.mergeJson({
-                "recordingCount": 0,
+                "recordingCount": (driveCount is int) ? driveCount : 0,
                 "scheduledCount": scheduledCount
             });
             monthlyStats.push(meta);
@@ -857,3 +897,4 @@ service http:InterceptableService / on new http:Listener(9090) {
         };
     }
 }
+

--- a/apps/meet-app/backend/service.bal
+++ b/apps/meet-app/backend/service.bal
@@ -16,7 +16,6 @@
 import meet_app.authorization;
 import meet_app.calendar;
 import meet_app.database;
-import meet_app.drive;
 import meet_app.people;
 import meet_app.sales;
 
@@ -59,6 +58,7 @@ service class ErrorInterceptor {
         return err;
     }
 }
+
 
 service http:InterceptableService / on new http:Listener(9090) {
 
@@ -675,21 +675,7 @@ service http:InterceptableService / on new http:Listener(9090) {
         }
 
         // Update editor permissions for all available video/mp4 attachments of the meeting.
-        foreach gcalendar:Attachment attachment in calendarEventAttachments ?: [] {
-            if attachment.mimeType == "video/mp4" {
-                drive:DrivePermissionResponse|error permissionResult = drive:setFilePermission(
-                        <string>attachment.fileId, drive:EDITOR, drive:USER, meeting.host
-                );
-
-                if permissionResult is error {
-                    string customError = string `Failed to update Editor permission for the host!`;
-                    log:printError(customError, permissionResult);
-                }
-            }
-        }
-
-        return {attachments: calendarEventAttachments ?: []};
-    }
+       
 
     # Delete meeting.
     #
@@ -834,14 +820,7 @@ service http:InterceptableService / on new http:Listener(9090) {
                 queryEndTime = endDate;
             }
 
-            // Drive API
-            future<int|error> fDrive = start drive:countWso2RecordingsInDateRange(queryStartTime, queryEndTime, region);
-            driveFutureMap[monthKey] = fDrive;
-            metaDataMap[monthKey] = {
-                "year": cursorYear,
-                "month": cursorMonth,
-                "key": monthKey
-            };
+           
 
             cursorMonth = cursorMonth + 1;
             if cursorMonth > 12 {


### PR DESCRIPTION
This pull request removes all usage and references to the `drive` module from the `apps/meet-app/backend/service.bal` file. The changes simplify the codebase by eliminating code related to Drive API integrations, such as updating editor permissions for attachments and counting WSO2 recordings.

### Removal of Drive API Integration

* Removed the import of the `meet_app.drive` module, as it is no longer used in the service.
* Deleted logic that updated editor permissions for `video/mp4` attachments via the Drive API in meeting handling endpoints.
* Removed asynchronous calls to `drive:countWso2RecordingsInDateRange` and associated metadata handling in the monthly data aggregation logic.

### Codebase Cleanup

* Eliminated unnecessary blank lines and improved formatting for better readability.

Fixes: https://github.com/wso2-enterprise/digiops-sales/issues/1552