### PR TITLE
[Meet App]: feat: update recording sharing logic to grant Drive access only to internal participants 

### DIFF
--- a/apps/meet-app/backend/meet_events_service.bal
+++ b/apps/meet-app/backend/meet_events_service.bal
@@ -174,19 +174,22 @@ isolated function processRecordingReady(string recordingName) returns error? {
     string[] internalEmails = tracked.internalParticipants.length() > 0
         ? commaSplit.split(tracked.internalParticipants).map(e => e.trim())
         : [];
-    string[] externalEmails = tracked.externalParticipants.length() > 0
-        ? commaSplit.split(tracked.externalParticipants).map(e => e.trim())
-        : [];
+    // Grant Drive view access only to internal (wso2.com) people -- the organizer plus the
+    // internal participants. External participants are deliberately excluded: WSO2 blocks
+    // sharing Drive files outside the org, so trying to grant them always failed, which kept
+    // the recording marked FAILED and made Pub/Sub retry the whole thing forever (re-sharing
+    // to everyone else on each retry). External attendees still get the calendar attachment.
+    string[] participantEmails = [tracked.organizer, ...internalEmails];
 
-    // The organizer isn't part of either participant list (those are just the other
-    // attendees), but they need view access to their own meeting's recording too.
-    string[] participantEmails = [tracked.organizer, ...internalEmails, ...externalEmails];
-    error? sharingFailure = ();
-
+    // Access-granting below is BEST-EFFORT. Failures are logged for follow-up but must never
+    // fail this function -- otherwise the webhook returns 503, Pub/Sub retries the whole event
+    // forever, and every retry re-attaches and re-shares (spamming everyone) while a permanent
+    // grant failure (e.g. a Drive cross-domain / silent-sharing restriction) never resolves.
+    // The recording is already attached at this point; that's the actual deliverable.
     driveservice:GrantResult[]|error shareResult = driveservice:grantAccess(fileId, participantEmails, true);
     if shareResult is error {
-        log:printError("Attached recording but some Drive permission grants failed.", shareResult);
-        sharingFailure = shareResult;
+        log:printError("Recording attached, but some participant Drive permission grants failed " +
+                "(best-effort, not retrying).", shareResult);
     }
 
     // Everyone in Sales, Channel Sales, and Sales Engineering also gets view access, even if
@@ -196,7 +199,6 @@ isolated function processRecordingReady(string recordingName) returns error? {
     if salesDepartmentEmails is error {
         log:printError("Could not fetch Sales department list; skipping their access grant for this recording.",
                 salesDepartmentEmails);
-        sharingFailure = salesDepartmentEmails;
     } else {
         string[] extraEmails = [];
         foreach string email in salesDepartmentEmails {
@@ -206,17 +208,15 @@ isolated function processRecordingReady(string recordingName) returns error? {
         }
         driveservice:GrantResult[]|error deptShareResult = driveservice:grantAccess(fileId, extraEmails, false);
         if deptShareResult is error {
-            log:printError("Attached recording but some Sales department Drive permission grants failed.",
-                    deptShareResult);
-            sharingFailure = deptShareResult;
+            log:printError("Recording attached, but some Sales department Drive permission grants failed " +
+                    "(best-effort, not retrying).", deptShareResult);
         }
     }
 
-    // Only mark ATTACHED once sharing has actually completed too -- otherwise a recording
-    // whose grants permanently failed (e.g. after Pub/Sub exhausts retries) would sit
-    // indistinguishable from a fully-completed one. FAILED here just means "not done yet,
-    // safe to reprocess": re-running is safe since both the attach and every grant call are
-    // idempotent, so a retry correctly redoes only what's still outstanding.
+    // The recording is attached -- mark ATTACHED and return success (200) regardless of how
+    // sharing went. Sharing failures are logged above for manual follow-up; they deliberately
+    // do NOT trigger a Pub/Sub retry. (A DB write failure below still surfaces as an error, so
+    // a genuinely transient DB problem is retried.)
     _ = check database:upsertMeetRecording({
         spaceName: tracked.spaceName,
         title: tracked.title,
@@ -226,9 +226,7 @@ isolated function processRecordingReady(string recordingName) returns error? {
         endTime: tracked.endTime,
         internalParticipants: tracked.internalParticipants,
         externalParticipants: tracked.externalParticipants,
-        recordingState: sharingFailure is () ? database:ATTACHED : database:FAILED,
+        recordingState: database:ATTACHED,
         driveFileId: fileId
     }, SYSTEM_ACTOR);
-
-    return sharingFailure;
 }

--- a/apps/meet-app/backend/modules/driveservice/drive.bal
+++ b/apps/meet-app/backend/modules/driveservice/drive.bal
@@ -40,9 +40,11 @@ public isolated function resolveRecording(string recordingName) returns Recordin
 #   Pass true for people who were actually on the call; false for broad, non-participant
 #   grants (e.g. every Sales/Channel Sales/Sales Engineering employee) so they don't get a
 #   "shared with you" email for every recording.
-# + return - Every per-email result, only if all of them succeeded; an aggregate error
-#   naming the emails that failed (and why) otherwise, so a partial failure doesn't get
-#   silently treated as a full success by callers that only check for `error`
+# + return - Every per-email result, only if all of them succeeded; otherwise an aggregate
+#   error carrying the failure count and the distinct reasons (deliberately NOT the email
+#   addresses, which are recipient PII we don't put in logs), so a partial failure isn't
+#   silently treated as a full success by callers that only check for `error`. The full
+#   per-email outcome is still available in the returned results on the success path.
 public isolated function grantAccess(string fileId, string[] emails, boolean sendNotificationEmail)
         returns GrantResult[]|error {
     http:Request req = new;
@@ -55,14 +57,23 @@ public isolated function grantAccess(string fileId, string[] emails, boolean sen
     json responseJson = check response.getJsonPayload();
     GrantAccessResponse grantResponse = check responseJson.cloneWithType(GrantAccessResponse);
 
-    string[] failureMessages = [];
+    // Aggregate failures WITHOUT the email addresses -- those are recipient PII we don't want
+    // in application logs. Keep only a count and the distinct failure reasons (Google's own
+    // error strings, which describe the permission problem, not the recipient).
+    int failedCount = 0;
+    string[] reasons = [];
     foreach GrantResult result in grantResponse.results {
         if !result.granted {
-            failureMessages.push(string `${result.email} (${result.'error ?: "unknown error"})`);
+            failedCount += 1;
+            string reason = result.'error ?: "unknown error";
+            if reasons.indexOf(reason) == () {
+                reasons.push(reason);
+            }
         }
     }
-    if failureMessages.length() > 0 {
-        return error(string `Drive permission grant failed for: ${string:'join(", ", ...failureMessages)}`);
+    if failedCount > 0 {
+        return error(string `${failedCount} of ${grantResponse.results.length()} Drive permission grant(s) failed. ` +
+                string `Reason(s): ${string:'join("; ", ...reasons)}`);
     }
     return grantResponse.results;
 }


### PR DESCRIPTION
This pull request updates the recording sharing logic in `meet_events_service.bal` to make Drive access-granting best-effort and avoid blocking the workflow on permanent sharing failures. Now, the system will always mark a recording as ATTACHED after attempting to grant access, regardless of whether all permissions were successfully granted. Sharing failures are logged for manual follow-up, but do not trigger retries or block further processing.

**Drive sharing and error handling changes:**

* Only internal participants (organizer and internal emails) are granted Drive access; external participants are excluded to avoid permanent failures due to org restrictions.
* All Drive access-granting steps are now best-effort: failures are logged but do not cause the function to return an error or trigger Pub/Sub retries. [[1]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L177-R192) [[2]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L209-R219)
* The `recordingState` is always set to `ATTACHED` after sharing attempts, regardless of sharing outcome. Previously, it could be marked as `FAILED` if any sharing failed.
* Removed the `sharingFailure` variable and related logic, simplifying error handling and ensuring retries only occur for genuine DB errors. [[1]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L199) [[2]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L229-L233)

**Comments and documentation:**

* Updated comments to clarify the new best-effort sharing behavior and rationale for not retrying on sharing failures. [[1]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L177-R192) [[2]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L209-R219)

Fixes: https://github.com/wso2-enterprise/digiops-sales/issues/1552