### PR TITLE
[Meet App] feat: add opportunityId to meet recording payload and database schema for linking meetings to Salesforce opportunities

### DIFF
--- a/apps/meet-app/backend/calendar_watch_service.bal
+++ b/apps/meet-app/backend/calendar_watch_service.bal
@@ -186,6 +186,14 @@ isolated function registerEventIfRelevant(json event) returns error? {
 
     string spaceName = check calendar:resolveSpaceName(meetingCode);
 
+    // Written by the RevOS add-on onto every event it creates or links -- absent (not an
+    // error) for a meeting that was never linked to a deal, e.g. tagged addOn by mistake.
+    string? opportunityId = ();
+    json|error opportunityIdResult = event.extendedProperties.'private.revos_opportunity_id;
+    if opportunityIdResult is string {
+        opportunityId = opportunityIdResult;
+    }
+
     json[] attendees = [];
     json|error attendeesResult = event.attendees;
     if attendeesResult is json[] {
@@ -228,6 +236,7 @@ isolated function registerEventIfRelevant(json event) returns error? {
         internalParticipants: string:'join(", ", ...internalEmails),
         externalParticipants: string:'join(", ", ...externalEmails),
         recordingState: database:PENDING,
-        driveFileId: ()
+        driveFileId: (),
+        opportunityId
     }, SYSTEM_ACTOR);
 }

--- a/apps/meet-app/backend/meet_events_service.bal
+++ b/apps/meet-app/backend/meet_events_service.bal
@@ -165,7 +165,8 @@ isolated function processRecordingReady(string recordingName) returns error? {
             internalParticipants: tracked.internalParticipants,
             externalParticipants: tracked.externalParticipants,
             recordingState: database:FAILED,
-            driveFileId: fileId
+            driveFileId: fileId,
+            opportunityId: tracked.opportunityId
         }, SYSTEM_ACTOR);
         return attachResult;
     }
@@ -227,6 +228,7 @@ isolated function processRecordingReady(string recordingName) returns error? {
         internalParticipants: tracked.internalParticipants,
         externalParticipants: tracked.externalParticipants,
         recordingState: database:ATTACHED,
-        driveFileId: fileId
+        driveFileId: fileId,
+        opportunityId: tracked.opportunityId
     }, SYSTEM_ACTOR);
 }

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -368,6 +368,7 @@ isolated function upsertMeetRecordingQuery(MeetRecordingPayload payload, string 
         external_participants,
         recording_state,
         drive_file_id,
+        opportunity_id,
         meeting_status,
         created_by,
         updated_by
@@ -385,6 +386,7 @@ isolated function upsertMeetRecordingQuery(MeetRecordingPayload payload, string 
         ${payload.externalParticipants},
         ${payload.recordingState},
         ${payload.driveFileId},
+        ${payload.opportunityId},
         ${ACTIVE},
         ${actor},
         ${actor}
@@ -401,6 +403,7 @@ isolated function upsertMeetRecordingQuery(MeetRecordingPayload payload, string 
         external_participants = VALUES(external_participants),
         recording_state = VALUES(recording_state),
         drive_file_id = VALUES(drive_file_id),
+        opportunity_id = VALUES(opportunity_id),
         updated_by = VALUES(updated_by)
 `;
 
@@ -438,7 +441,8 @@ isolated function getMeetRecordingBySpaceNameQuery(string spaceName) returns sql
         wso2_participants AS internalParticipants,
         external_participants AS externalParticipants,
         recording_state AS recordingState,
-        drive_file_id AS driveFileId
+        drive_file_id AS driveFileId,
+        opportunity_id AS opportunityId
     FROM meeting
     WHERE space_name = ${spaceName}
 `;

--- a/apps/meet-app/backend/modules/database/types.bal
+++ b/apps/meet-app/backend/modules/database/types.bal
@@ -180,6 +180,7 @@ public enum RecordingState {
 # + externalParticipants - Non-wso2.com attendees, comma-joined
 # + recordingState - Current processing state
 # + driveFileId - Drive file ID of the recording, once resolved
+# + opportunityId - Salesforce Opportunity ID this call was scheduled for, if any
 public type MeetRecordingPayload record {|
     string title;
     string spaceName;
@@ -191,6 +192,7 @@ public type MeetRecordingPayload record {|
     string externalParticipants;
     RecordingState recordingState;
     string? driveFileId = ();
+    string? opportunityId = ();
 |};
 
 # [Database] An auto-recorded meeting row, read back by space name.
@@ -206,6 +208,7 @@ public type MeetRecordingPayload record {|
 # + externalParticipants - Non-wso2.com attendees, comma-joined
 # + recordingState - Current processing state
 # + driveFileId - Drive file ID of the recording, if resolved yet
+# + opportunityId - Salesforce Opportunity ID this call was scheduled for, if any
 public type MeetRecordingRow record {|
     int meetingId;
     string spaceName;
@@ -218,4 +221,5 @@ public type MeetRecordingRow record {|
     string externalParticipants;
     RecordingState recordingState;
     string? driveFileId;
+    string? opportunityId;
 |};

--- a/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
+++ b/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
@@ -26,6 +26,13 @@ CREATE TABLE calendar_watch_state (
 
 INSERT INTO calendar_watch_state (id, sync_token) VALUES (1, NULL);
 
+-- Links an auto-recorded meeting back to the Salesforce Opportunity it was scheduled for.
+-- Value comes from the calendar event's own extendedProperties.private.revos_opportunity_id
+-- (written by the RevOS add-on). NULL for the existing manual-scheduling flow, which has no
+-- Salesforce opportunity at all.
+ALTER TABLE people_ops_suite.meeting
+ADD COLUMN `opportunity_id` VARCHAR(255) NULL;
+
 
 
 -- Prevents two concurrent upsertMeetRecording calls from ever creating duplicate rows for


### PR DESCRIPTION
This pull request adds support for associating meetings and their recordings with Salesforce Opportunity IDs, enabling better integration with CRM workflows. The changes ensure that if a meeting is linked to a Salesforce Opportunity (via the RevOS add-on), this information is captured, persisted, and propagated throughout the backend services and database.

**Database schema and data model updates:**

* Added a new nullable `opportunity_id` column to the `meeting` table to store the Salesforce Opportunity ID for each meeting.
* Updated the `MeetRecordingPayload` and `MeetRecordingRow` record types to include an optional `opportunityId` field, with documentation on its purpose. [[1]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R183) [[2]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R195) [[3]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R211) [[4]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R224)

**Backend logic and query changes:**

* Modified the event registration logic in `calendar_watch_service.bal` to extract the `revos_opportunity_id` from the event's extended properties and include it in the meeting record if present. [[1]](diffhunk://#diff-082f3124084808e7d1d87cc96b08ed5bd66813be19624b89fdc024d3acfdfabbR189-R196) [[2]](diffhunk://#diff-082f3124084808e7d1d87cc96b08ed5bd66813be19624b89fdc024d3acfdfabbL231-R240)
* Updated the SQL queries for inserting, updating, and retrieving meeting recordings to handle the new `opportunity_id` field, ensuring it is properly stored and fetched. [[1]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aR371) [[2]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aR389) [[3]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aR406) [[4]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aL441-R445)
* Ensured that the opportunity ID is propagated during recording processing and status updates in `meet_events_service.bal`. [[1]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L168-R169) [[2]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L230-R232)

Fixes: https://github.com/wso2-enterprise/digiops-sales/issues/1552