### PR TITLE
[Meet App] feat: add authentication to /calendar-watch` and `/meet-events and add Salesforce Opportunity details to db

### DIFF
--- a/apps/meet-app/backend/calendar_watch_renewal.bal
+++ b/apps/meet-app/backend/calendar_watch_renewal.bal
@@ -98,5 +98,13 @@ isolated function scheduleRenewal(decimal delaySeconds) {
 }
 
 function init() returns error? {
+    // Fail closed on a missing watch-channel secret. calendarWatchToken is required, but an
+    // empty deployed value ("") would make the /calendar-watch token check and the /register
+    // admin-token guard accept an attacker-supplied empty token -- so refuse to start rather
+    // than run open (CWE-1188).
+    if calendarWatchToken.trim() == "" {
+        return error("calendarWatchToken is not configured; refusing to start with an empty " +
+                "watch-channel secret (the /calendar-watch and /register endpoints would fail open).");
+    }
     scheduleRenewal(0);
 }

--- a/apps/meet-app/backend/calendar_watch_service.bal
+++ b/apps/meet-app/backend/calendar_watch_service.bal
@@ -30,14 +30,27 @@ service /calendar\-watch on new http:Listener(calendarWatchListenerPort) {
 
     # One-time manual setup/testing endpoint: registers a watch channel on the Shared
     # Account's calendar directly, bypassing the self-renewing scheduled job in
-    # calendar_watch_renewal.bal. Point webhookUrl at this same service's own tunnel URL,
-    # with "/calendar-watch" appended.
+    # calendar_watch_renewal.bal. Point webhookUrl at this same service's own base URL --
+    # Choreo's exposed path for this service already IS the "/calendar-watch" root, so
+    # nothing further should be appended.
+    #
+    # Guarded by adminToken (reusing calendarWatchToken as a second, unrelated purpose --
+    # it is otherwise just the ping-matching secret) because this whole service has to sit
+    # unauthenticated at the Choreo gateway for Google's own webhook pings to ever reach
+    # the resource below, which would otherwise leave this registration action wide open to
+    # anyone on the internet.
     #
     # + webhookUrl - Publicly reachable URL for Google to send pings to
     # + channelId - Unique ID for this channel (pick any new string each time you register)
+    # + adminToken - Must match the configured calendarWatchToken
     # + return - The registered channel's details, or error
-    resource function post register(string webhookUrl, string channelId)
-            returns calendar:WatchChannelResponse|http:InternalServerError {
+    resource function post register(string webhookUrl, string channelId, string adminToken)
+            returns calendar:WatchChannelResponse|http:InternalServerError|http:Unauthorized {
+        if adminToken != calendarWatchToken {
+            log:printError("Calendar watch registration attempt had a missing or mismatched admin token; refusing.");
+            return <http:Unauthorized>{body: {message: "Unauthorized."}};
+        }
+
         calendar:WatchChannelResponse|error result = calendar:watchCalendar(webhookUrl, channelId, calendarWatchToken);
         if result is error {
             log:printError("Failed to register calendar watch channel.", result);
@@ -194,6 +207,15 @@ isolated function registerEventIfRelevant(json event) returns error? {
         opportunityId = opportunityIdResult;
     }
 
+    // Compact deal snapshot (name, stage, amount, account, close date) the add-on writes as
+    // one JSON-string property. Stored as-is -- MySQL validates it as JSON on insert, nothing
+    // here needs to parse it back out.
+    string? opportunityDetails = ();
+    json|error opportunitySnapshotResult = event.extendedProperties.'private.revos_opportunity_snapshot;
+    if opportunitySnapshotResult is string {
+        opportunityDetails = opportunitySnapshotResult;
+    }
+
     json[] attendees = [];
     json|error attendeesResult = event.attendees;
     if attendeesResult is json[] {
@@ -237,6 +259,7 @@ isolated function registerEventIfRelevant(json event) returns error? {
         externalParticipants: string:'join(", ", ...externalEmails),
         recordingState: database:PENDING,
         driveFileId: (),
-        opportunityId
+        opportunityId,
+        opportunityDetails
     }, SYSTEM_ACTOR);
 }

--- a/apps/meet-app/backend/calendar_watch_service.bal
+++ b/apps/meet-app/backend/calendar_watch_service.bal
@@ -209,11 +209,15 @@ isolated function registerEventIfRelevant(json event) returns error? {
 
     // Compact deal snapshot (name, stage, amount, account, close date) the add-on writes as
     // one JSON-string property. Stored as-is -- MySQL validates it as JSON on insert, nothing
-    // here needs to parse it back out.
+    // here needs to parse it back out. Only captured when an opportunityId is also present, so
+    // the row can never hold deal details without the id they belong to (matches the schema's
+    // documented "NULL wherever opportunity_id is NULL" invariant).
     string? opportunityDetails = ();
-    json|error opportunitySnapshotResult = event.extendedProperties.'private.revos_opportunity_snapshot;
-    if opportunitySnapshotResult is string {
-        opportunityDetails = opportunitySnapshotResult;
+    if opportunityId is string {
+        json|error opportunitySnapshotResult = event.extendedProperties.'private.revos_opportunity_snapshot;
+        if opportunitySnapshotResult is string {
+            opportunityDetails = opportunitySnapshotResult;
+        }
     }
 
     json[] attendees = [];

--- a/apps/meet-app/backend/config.toml.local
+++ b/apps/meet-app/backend/config.toml.local
@@ -119,9 +119,23 @@
     meetEventsListenerPort = 9091
     # The Shared Account whose calendar is watched for add-on meetings.
     sharedAccountEmail = ""
-    # Shared secret Google echoes back on every watch ping (pick any value).
+    # Strong random shared secret Google echoes back on every watch ping. Use a long random
+    # value (e.g. `openssl rand -hex 32`), NOT a guessable string, and match it when
+    # registering the channel.
     calendarWatchToken = ""
     # Public URL of THIS service's calendar-watch (9093) endpoint that Google pings.
     calendarWatchWebhookUrl = ""
     # Any stable prefix used when naming watch channels.
     calendarWatchChannelIdPrefix = ""
+
+    # Pub/Sub push authentication for the /meet-events (9091) endpoint. This endpoint is
+    # unauthenticated at the gateway (Google's push carries no gateway credential), so the
+    # caller is verified here via the Google-signed OIDC token Pub/Sub attaches when the push
+    # subscription is created with --push-auth-service-account.
+    #   Keep pubsubAuthEnabled=false until the push subscription has been (re)created with an
+    #   auth service account; then set the two values below and flip to true.
+    pubsubAuthEnabled = false
+    # Service account set as the push subscription's auth identity (the token's `email` claim).
+    pubsubPushServiceAccount = ""
+    # Audience the token must carry (--push-auth-token-audience, or the push endpoint URL).
+    pubsubPushAudience = ""

--- a/apps/meet-app/backend/meet_events_service.bal
+++ b/apps/meet-app/backend/meet_events_service.bal
@@ -131,8 +131,10 @@ type SeedRegistryRequest record {|
 |};
 
 // Isolated listener, deliberately separate from the main Asgardeo-gated service on 9090.
-// No push-token verification for now -- accepted trade-off for today's demo, behind a
-// short-lived tunnel URL; revisit before this is ever exposed on a stable public endpoint.
+// This endpoint is unauthenticated at the Choreo gateway (Google's Pub/Sub push carries no
+// gateway credential), so the caller is authenticated in-app: when pubsubAuthEnabled is set,
+// verifyPubsubPush() validates the Google-signed OIDC token on every push; when disabled
+// (the staged-rollout default) verification is skipped.
 service /meet\-events on new http:Listener(meetEventsListenerPort) {
 
     # One-off manual seed -- see SeedRegistryRequest.

--- a/apps/meet-app/backend/meet_events_service.bal
+++ b/apps/meet-app/backend/meet_events_service.bal
@@ -19,12 +19,64 @@ import meet_app.driveservice;
 import meet_app.people;
 
 import ballerina/http;
+import ballerina/jwt;
 import ballerina/lang.array;
 import ballerina/lang.'string as strings;
 import ballerina/lang.value;
 import ballerina/log;
 
 configurable int meetEventsListenerPort = 9091;
+
+// Authentication of the Pub/Sub push. This endpoint must sit unauthenticated at the Choreo
+// gateway (Google's push carries no Choreo credential), so the caller is authenticated HERE
+// instead, by verifying the Google-signed OIDC token Pub/Sub attaches when the push
+// subscription is configured with a service account. Gated on `pubsubAuthEnabled` so the code
+// can be deployed first and enforcement switched on only once the push subscription has been
+// (re)created with `--push-auth-service-account`; otherwise real messages -- which would not
+// yet carry a token -- would be rejected.
+configurable boolean pubsubAuthEnabled = false;
+// The service account set as the push subscription's auth identity; must equal the token's
+// `email` claim.
+configurable string pubsubPushServiceAccount = "";
+// The audience the token must carry -- the value passed to `--push-auth-token-audience`, or
+// the push endpoint URL if no override was set.
+configurable string pubsubPushAudience = "";
+
+// Google's OIDC issuer and public-key (JWKS) endpoint for verifying Pub/Sub push tokens.
+const string GOOGLE_OIDC_ISSUER = "https://accounts.google.com";
+const string GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+
+# Verifies the Google-signed OIDC token on a Pub/Sub push. Returns an error (which the caller
+# turns into a 401) if enforcement is on and the token is missing, malformed, wrongly signed,
+# or does not carry the expected issuer/audience/service-account. A no-op when enforcement is
+# off.
+#
+# + authorization - The raw `Authorization` header value (expected `Bearer <jwt>`)
+# + return - `()` if authenticated (or enforcement disabled), else an error
+isolated function verifyPubsubPush(string? authorization) returns error? {
+    if !pubsubAuthEnabled {
+        return;
+    }
+    if authorization is () || !authorization.startsWith("Bearer ") {
+        return error("Missing or malformed Authorization header on Pub/Sub push.");
+    }
+    string token = authorization.substring(7).trim();
+    jwt:ValidatorConfig validatorConfig = {
+        issuer: GOOGLE_OIDC_ISSUER,
+        audience: pubsubPushAudience,
+        signatureConfig: {jwksConfig: {url: GOOGLE_JWKS_URL}}
+    };
+    jwt:Payload payload = check jwt:validate(token, validatorConfig);
+    anydata email = payload["email"];
+    anydata emailVerified = payload["email_verified"];
+    if email != pubsubPushServiceAccount {
+        return error(string `Pub/Sub push token 'email' claim did not match the expected push service account.`);
+    }
+    if emailVerified != true {
+        return error("Pub/Sub push token 'email_verified' claim was not true.");
+    }
+    return;
+}
 
 // Writes performed by these automated flows aren't tied to a specific logged-in user,
 // unlike the rest of this app's created_by/updated_by values.
@@ -107,11 +159,22 @@ service /meet\-events on new http:Listener(meetEventsListenerPort) {
         return <http:Ok>{body: {message: "seeded"}};
     }
 
+    # + authorization - `Authorization: Bearer <OIDC JWT>` header Pub/Sub attaches when the
+    #   push subscription is configured with an auth service account
     # + envelope - The Pub/Sub push envelope
-    # + return - 200 once processed, or if the message is permanently unparseable (retrying
-    #   a malformed message would never help); 503 on a genuine processing failure, since
-    #   Pub/Sub retries non-2xx responses with backoff automatically
-    resource function post .(@http:Payload PubSubPushEnvelope envelope) returns http:Ok|http:ServiceUnavailable {
+    # + return - 401 if the push token is missing/invalid (enforcement on); 200 once processed,
+    #   or if the message is permanently unparseable (retrying a malformed message would never
+    #   help); 503 on a genuine processing failure, since Pub/Sub retries non-2xx responses
+    #   with backoff automatically
+    resource function post .(@http:Header {name: "Authorization"} string? authorization,
+            @http:Payload PubSubPushEnvelope envelope)
+            returns http:Ok|http:Unauthorized|http:ServiceUnavailable {
+        error? authResult = verifyPubsubPush(authorization);
+        if authResult is error {
+            log:printError("Rejected unauthenticated/invalid Pub/Sub push.", authResult);
+            return <http:Unauthorized>{body: {message: "Unauthorized."}};
+        }
+
         byte[]|error decoded = array:fromBase64(envelope.message.data);
         if decoded is error {
             log:printError("Could not base64-decode Pub/Sub message data.", decoded);
@@ -166,7 +229,8 @@ isolated function processRecordingReady(string recordingName) returns error? {
             externalParticipants: tracked.externalParticipants,
             recordingState: database:FAILED,
             driveFileId: fileId,
-            opportunityId: tracked.opportunityId
+            opportunityId: tracked.opportunityId,
+            opportunityDetails: tracked.opportunityDetails
         }, SYSTEM_ACTOR);
         return attachResult;
     }
@@ -229,6 +293,7 @@ isolated function processRecordingReady(string recordingName) returns error? {
         externalParticipants: tracked.externalParticipants,
         recordingState: database:ATTACHED,
         driveFileId: fileId,
-        opportunityId: tracked.opportunityId
+        opportunityId: tracked.opportunityId,
+        opportunityDetails: tracked.opportunityDetails
     }, SYSTEM_ACTOR);
 }

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -369,6 +369,7 @@ isolated function upsertMeetRecordingQuery(MeetRecordingPayload payload, string 
         recording_state,
         drive_file_id,
         opportunity_id,
+        opportunity_details,
         meeting_status,
         created_by,
         updated_by
@@ -387,6 +388,7 @@ isolated function upsertMeetRecordingQuery(MeetRecordingPayload payload, string 
         ${payload.recordingState},
         ${payload.driveFileId},
         ${payload.opportunityId},
+        ${payload.opportunityDetails},
         ${ACTIVE},
         ${actor},
         ${actor}
@@ -404,6 +406,7 @@ isolated function upsertMeetRecordingQuery(MeetRecordingPayload payload, string 
         recording_state = VALUES(recording_state),
         drive_file_id = VALUES(drive_file_id),
         opportunity_id = VALUES(opportunity_id),
+        opportunity_details = VALUES(opportunity_details),
         updated_by = VALUES(updated_by)
 `;
 
@@ -442,7 +445,8 @@ isolated function getMeetRecordingBySpaceNameQuery(string spaceName) returns sql
         external_participants AS externalParticipants,
         recording_state AS recordingState,
         drive_file_id AS driveFileId,
-        opportunity_id AS opportunityId
+        opportunity_id AS opportunityId,
+        opportunity_details AS opportunityDetails
     FROM meeting
     WHERE space_name = ${spaceName}
 `;

--- a/apps/meet-app/backend/modules/database/types.bal
+++ b/apps/meet-app/backend/modules/database/types.bal
@@ -181,6 +181,9 @@ public enum RecordingState {
 # + recordingState - Current processing state
 # + driveFileId - Drive file ID of the recording, once resolved
 # + opportunityId - Salesforce Opportunity ID this call was scheduled for, if any
+# + opportunityDetails - Compact JSON snapshot of the deal (name, stage, amount, account, close
+# date), as a raw JSON string -- stored as-is, not parsed, since nothing here needs individual
+# fields out of it
 public type MeetRecordingPayload record {|
     string title;
     string spaceName;
@@ -193,6 +196,7 @@ public type MeetRecordingPayload record {|
     RecordingState recordingState;
     string? driveFileId = ();
     string? opportunityId = ();
+    string? opportunityDetails = ();
 |};
 
 # [Database] An auto-recorded meeting row, read back by space name.
@@ -209,6 +213,7 @@ public type MeetRecordingPayload record {|
 # + recordingState - Current processing state
 # + driveFileId - Drive file ID of the recording, if resolved yet
 # + opportunityId - Salesforce Opportunity ID this call was scheduled for, if any
+# + opportunityDetails - Compact JSON snapshot of the deal, as a raw JSON string
 public type MeetRecordingRow record {|
     int meetingId;
     string spaceName;
@@ -222,4 +227,5 @@ public type MeetRecordingRow record {|
     RecordingState recordingState;
     string? driveFileId;
     string? opportunityId;
+    string? opportunityDetails;
 |};

--- a/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
+++ b/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
@@ -33,6 +33,12 @@ INSERT INTO calendar_watch_state (id, sync_token) VALUES (1, NULL);
 ALTER TABLE people_ops_suite.meeting
 ADD COLUMN `opportunity_id` VARCHAR(255) NULL;
 
+-- Compact deal context (name, stage, amount, account, close date) alongside the meeting,
+-- from the event's extendedProperties.private.revos_opportunity_snapshot -- a JSON string
+-- the add-on already builds and writes onto the event. NULL wherever opportunity_id is NULL.
+ALTER TABLE people_ops_suite.meeting
+ADD COLUMN `opportunity_details` JSON NULL;
+
 
 
 -- Prevents two concurrent upsertMeetRecording calls from ever creating duplicate rows for


### PR DESCRIPTION
This pull request introduces two main sets of changes: (1) it adds authentication and security improvements for the `/calendar-watch` and `/meet-events` endpoints, and (2) it extends the meeting database schema and backend logic to persist a compact JSON snapshot of Salesforce Opportunity details with each meeting. These changes improve security for webhook endpoints and enhance the application's ability to track deal context for meetings.

**Security and authentication improvements:**

* The `/calendar-watch/register` endpoint now requires an `adminToken` (reusing `calendarWatchToken`) and returns 401 Unauthorized if the token is missing or incorrect, to prevent unauthorized manual channel registration.
* The `/meet-events` endpoint now supports verification of Google-signed OIDC tokens on Pub/Sub pushes, gated by a new `pubsubAuthEnabled` config. If enabled, pushes without a valid token are rejected with 401 Unauthorized. [[1]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31R22-R80) [[2]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31R162-R177)
* Configuration documentation and parameters for Pub/Sub push authentication were added to `config.toml.local`.

**Opportunity details persistence:**

* The backend now reads the compact JSON deal snapshot (`extendedProperties.private.revos_opportunity_snapshot`) from calendar events and persists it as `opportunityDetails` alongside each meeting record. This is stored as a raw JSON string and not parsed by the backend. [[1]](diffhunk://#diff-082f3124084808e7d1d87cc96b08ed5bd66813be19624b89fdc024d3acfdfabbR210-R218) [[2]](diffhunk://#diff-082f3124084808e7d1d87cc96b08ed5bd66813be19624b89fdc024d3acfdfabbL240-R263) [[3]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L169-R233) [[4]](diffhunk://#diff-a4e8f2c62f832cba95fd4cc3aff9c72159eb5cad08ab4521a1e3cf3c340ada31L232-R297)
* The `meeting` table schema is altered to add a new `opportunity_details` JSON column, and all relevant database types, queries, and upsert logic are updated to handle this new field. [[1]](diffhunk://#diff-b85aace328bd405c2294343fad1da2992fbf1fdacdb0c52741dc20e9a65d64c8R36-R41) [[2]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aR372) [[3]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aR391) [[4]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aR409) [[5]](diffhunk://#diff-19ea471d494b61637d35e494e454b016a5353f2c039d5553b4457151fc6a1d1aL445-R449) [[6]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R184-R186) [[7]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R199) [[8]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R216) [[9]](diffhunk://#diff-09657bf033245c8b602f652b90ccd01eef191cd5d79bab1f35ad1214e435e644R230)

Fixes: https://github.com/wso2-enterprise/digiops-sales/issues/1552