### PR TITLE
[Meet App] fix: update watchCalendar function to check for 201 status code and remove stopWatchChannel function

### DIFF
--- a/apps/meet-app/backend/modules/calendar/meet.bal
+++ b/apps/meet-app/backend/modules/calendar/meet.bal
@@ -61,26 +61,12 @@ public isolated function watchCalendar(string webhookUrl, string channelId, stri
     http:Request req = new;
     req.setPayload({webhookUrl, channelId, token});
     http:Response response = check calendarClient->post(string `/calendars/${calendarId}/watch`, req);
-    if response.statusCode != 200 {
+    if response.statusCode != 201 {
         json? errorResponseBody = check response.getJsonPayload();
         return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
     }
     json responseJson = check response.getJsonPayload();
     return responseJson.cloneWithType(WatchChannelResponse);
-}
-
-# Stops a previously-registered Calendar watch channel before it naturally expires, via CES.
-#
-# + channelId - The channel's own ID, from when it was registered
-# + resourceId - The resourceId Google assigned when the channel was registered
-# + return - Error if stopping fails
-public isolated function stopWatchChannel(string channelId, string resourceId) returns error? {
-    http:Response response = check calendarClient->post(
-            string `/calendars/${calendarId}/watch/stop?channelId=${channelId}&resourceId=${resourceId}`, {});
-    if response.statusCode != 200 {
-        json? errorResponseBody = check response.getJsonPayload();
-        return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
-    }
 }
 
 # Resolves a meeting's join code to its real Meet space resource name, via CES.

--- a/apps/meet-app/backend/modules/calendar/meet.bal
+++ b/apps/meet-app/backend/modules/calendar/meet.bal
@@ -61,7 +61,7 @@ public isolated function watchCalendar(string webhookUrl, string channelId, stri
     http:Request req = new;
     req.setPayload({webhookUrl, channelId, token});
     http:Response response = check calendarClient->post(string `/calendars/${calendarId}/watch`, req);
-    if response.statusCode != 201 {
+    if response.statusCode != 200 && response.statusCode != 201 {
         json? errorResponseBody = check response.getJsonPayload();
         return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
     }


### PR DESCRIPTION
This pull request makes two main changes to the calendar watch functionality in the Meet app backend. The status code check for successful calendar watch creation is updated to match the expected API response, and the function for stopping a calendar watch channel has been removed.

**Calendar Watch API Updates:**

* Changed the status code check in `watchCalendar` to expect `201` (Created) instead of `200` (OK), ensuring correct handling of successful watch creation responses.

**Code Cleanup:**

* Removed the `stopWatchChannel` function, which was responsible for stopping a previously-registered calendar watch channel. This includes deleting the function implementation and its documentation.