### PR TITLE
[Meet App]: feature: Opportunity Data Fetching and Handling

### DIFF
--- a/apps/meet-app/backend/calendar_watch_service.bal
+++ b/apps/meet-app/backend/calendar_watch_service.bal
@@ -211,24 +211,37 @@ isolated function registerEventIfRelevant(json event) returns error? {
 
     string spaceName = check calendar:resolveSpaceName(meetingCode);
 
-    // Written by the RevOS add-on onto every event it creates or links -- absent (not an
-    // error) for a meeting that was never linked to a deal, e.g. tagged addOn by mistake.
+    // Written by the RevOS add-on onto every event it creates or links, as PRIVATE extended
+    // properties -- which Google scopes to the one calendar copy they were set on (the
+    // organizer's), not to the event generally. The Shared Account's own copy of this event
+    // (what `event` here is -- read via the calendar-watch poll) never has them, so they're
+    // read from a separate, targeted fetch of the organizer's own copy instead, impersonated
+    // via CES's existing DWD credential. A failure here (or the properties genuinely being
+    // absent, e.g. an event tagged addOn by mistake with no deal linked) is not fatal --
+    // the meeting is still tracked, just without opportunity data.
     string? opportunityId = ();
-    json|error opportunityIdResult = event.extendedProperties.'private.revos_opportunity_id;
-    if opportunityIdResult is string {
-        opportunityId = opportunityIdResult;
-    }
-
-    // Compact deal snapshot (name, stage, amount, account, close date) the add-on writes as
-    // one JSON-string property. Stored as-is -- MySQL validates it as JSON on insert, nothing
-    // here needs to parse it back out. Only captured when an opportunityId is also present, so
-    // the row can never hold deal details without the id they belong to (matches the schema's
-    // documented "NULL wherever opportunity_id is NULL" invariant).
     string? opportunityDetails = ();
-    if opportunityId is string {
-        json|error opportunitySnapshotResult = event.extendedProperties.'private.revos_opportunity_snapshot;
-        if opportunitySnapshotResult is string {
-            opportunityDetails = opportunitySnapshotResult;
+    json|error organizerEventResult = calendar:getEvent(organizerEmail, eventId);
+    if organizerEventResult is error {
+        log:printError(string `Could not fetch organizer's own copy of event ${eventId} to read ` +
+                "opportunity properties; continuing without them.", organizerEventResult);
+    } else {
+        json|error opportunityIdResult = organizerEventResult.extendedProperties.'private.revos_opportunity_id;
+        if opportunityIdResult is string {
+            opportunityId = opportunityIdResult;
+        }
+
+        // Compact deal snapshot (name, stage, amount, account, close date) the add-on writes
+        // as one JSON-string property. Stored as-is -- MySQL validates it as JSON on insert,
+        // nothing here needs to parse it back out. Only captured when an opportunityId is
+        // also present, so the row can never hold deal details without the id they belong to
+        // (matches the schema's documented "NULL wherever opportunity_id is NULL" invariant).
+        if opportunityId is string {
+            json|error opportunitySnapshotResult =
+                organizerEventResult.extendedProperties.'private.revos_opportunity_snapshot;
+            if opportunitySnapshotResult is string {
+                opportunityDetails = opportunitySnapshotResult;
+            }
         }
     }
 
@@ -264,7 +277,7 @@ isolated function registerEventIfRelevant(json event) returns error? {
         return;
     }
 
-    _ = check database:upsertMeetRecording({
+    _ = check database:registerMeetRecording({
         spaceName,
         title,
         googleEventId: eventId,

--- a/apps/meet-app/backend/modules/calendar/meet.bal
+++ b/apps/meet-app/backend/modules/calendar/meet.bal
@@ -69,6 +69,25 @@ public isolated function watchCalendar(string webhookUrl, string channelId, stri
     return responseJson.cloneWithType(WatchChannelResponse);
 }
 
+# Gets a single event as a specific user would see it (impersonated via CES's own DWD
+# credential), via CES. Needed specifically to read `extendedProperties.private` values the
+# RevOS add-on writes -- Google scopes "private" extended properties to the one calendar
+# copy they were set on, so they're only visible when reading the *organizer's* own copy of
+# the event, not the Shared Account's (an attendee's) copy that the calendar-watch poll
+# (getChangedEvents) returns.
+#
+# + organizerEmail - Whose copy of the event to read, impersonated via CES's DWD credential
+# + eventId - The event's ID
+# + return - The event as raw JSON (only `extendedProperties` is actually used), or error
+public isolated function getEvent(string organizerEmail, string eventId) returns json|error {
+    http:Response response = check calendarClient->get(string `/calendars/${organizerEmail}/events/${eventId}`);
+    if response.statusCode != 200 {
+        json? errorResponseBody = check response.getJsonPayload();
+        return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
+    }
+    return response.getJsonPayload();
+}
+
 # Resolves a meeting's join code to its real Meet space resource name, via CES.
 #
 # + meetingCode - The short code from a meet.google.com/xxx-xxxx-xxx URL

--- a/apps/meet-app/backend/modules/database/db_functions.bal
+++ b/apps/meet-app/backend/modules/database/db_functions.bal
@@ -178,6 +178,19 @@ public isolated function upsertMeetRecording(MeetRecordingPayload payload, strin
     return result.lastInsertId.ensureType(int);
 }
 
+# Registers (or refreshes non-recording details of) an auto-recorded meeting row, keyed by
+# space name -- for calendar-watch's own use. Unlike upsertMeetRecording, this never
+# overwrites recording_state/drive_file_id on an existing row; see
+# registerMeetRecordingQuery for why.
+#
+# + payload - Details to write
+# + actor - User performing the write
+# + return - The row's meeting_id, or Error
+public isolated function registerMeetRecording(MeetRecordingPayload payload, string actor) returns int|error {
+    sql:ExecutionResult result = check databaseClient->execute(registerMeetRecordingQuery(payload, actor));
+    return result.lastInsertId.ensureType(int);
+}
+
 # Gets the stored Calendar-watch sync token, if one's been set yet.
 #
 # + return - The stored sync token, `()` if none stored yet, or Error

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -410,6 +410,73 @@ isolated function upsertMeetRecordingQuery(MeetRecordingPayload payload, string 
         updated_by = VALUES(updated_by)
 `;
 
+# Build an insert-or-refresh query for calendar-watch's own registration of an event,
+# keyed the same way as upsertMeetRecordingQuery. Deliberately does NOT overwrite
+# recording_state/drive_file_id on the duplicate-key (update) path -- calendar-watch can
+# be notified again about an event it already registered (e.g. attaching a recording is
+# itself a calendar-event edit, which triggers another change notification), and blindly
+# resetting those two columns back to their initial values would erase progress
+# processRecordingReady() already made. They're still set correctly on a genuine first
+# insert, since VALUES(...) in the INSERT list still applies then.
+#
+# + payload - Details to write
+# + actor - User performing the write
+# + return - sql:ParameterizedQuery - Insert-or-refresh query for the meeting table
+isolated function registerMeetRecordingQuery(MeetRecordingPayload payload, string actor) returns sql:ParameterizedQuery =>
+`
+    INSERT INTO meeting
+    (
+        title,
+        space_name,
+        google_event_id,
+        host,
+        event_creator,
+        start_time,
+        end_time,
+        wso2_participants,
+        external_participants,
+        recording_state,
+        drive_file_id,
+        opportunity_id,
+        opportunity_details,
+        meeting_status,
+        created_by,
+        updated_by
+    )
+    VALUES
+    (
+        ${payload.title},
+        ${payload.spaceName},
+        ${payload.googleEventId},
+        ${payload.organizer},
+        ${payload.organizer},
+        ${payload.startTime},
+        ${payload.endTime},
+        ${payload.internalParticipants},
+        ${payload.externalParticipants},
+        ${payload.recordingState},
+        ${payload.driveFileId},
+        ${payload.opportunityId},
+        ${payload.opportunityDetails},
+        ${ACTIVE},
+        ${actor},
+        ${actor}
+    )
+    ON DUPLICATE KEY UPDATE
+        meeting_id = LAST_INSERT_ID(meeting_id),
+        title = VALUES(title),
+        google_event_id = VALUES(google_event_id),
+        host = VALUES(host),
+        event_creator = VALUES(event_creator),
+        start_time = VALUES(start_time),
+        end_time = VALUES(end_time),
+        wso2_participants = VALUES(wso2_participants),
+        external_participants = VALUES(external_participants),
+        opportunity_id = VALUES(opportunity_id),
+        opportunity_details = VALUES(opportunity_details),
+        updated_by = VALUES(updated_by)
+`;
+
 # Build query to fetch the stored Calendar-watch sync token.
 #
 # + return - sql:ParameterizedQuery - Select query for the calendar_watch_state table

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -472,8 +472,8 @@ isolated function registerMeetRecordingQuery(MeetRecordingPayload payload, strin
         end_time = VALUES(end_time),
         wso2_participants = VALUES(wso2_participants),
         external_participants = VALUES(external_participants),
-        opportunity_id = VALUES(opportunity_id),
-        opportunity_details = VALUES(opportunity_details),
+        opportunity_id = IF(VALUES(opportunity_id) IS NULL, opportunity_id, VALUES(opportunity_id)),
+        opportunity_details = IF(VALUES(opportunity_id) IS NULL, opportunity_details, VALUES(opportunity_details)),
         updated_by = VALUES(updated_by)
 `;
 


### PR DESCRIPTION
This pull request enhances how calendar event data is registered and updated, especially regarding opportunity information from the RevOS add-on. The main improvements ensure that private extended properties are reliably fetched from the organizer's event copy, and that meeting registration avoids overwriting important recording information. It also introduces a new database function and query to support this logic.

Key changes:

**Opportunity Data Fetching and Handling:**

* Updated `registerEventIfRelevant` to fetch private extended properties (`revos_opportunity_id` and `revos_opportunity_snapshot`) by impersonating the organizer and reading their own event copy, since these properties are not present on the shared account's event copy. This ensures opportunity data is captured when available, but gracefully continues if not.
* Added a new `getEvent` function in `calendar/meet.bal` to fetch an event as seen by the organizer, enabling access to organizer-scoped private properties.

**Database Registration and Query Logic:**

* Introduced a new database function `registerMeetRecording` that registers or refreshes meeting rows without overwriting `recording_state` or `drive_file_id` on updates. This prevents accidental loss of recording progress if the same event is registered multiple times.
* Added the corresponding `registerMeetRecordingQuery` SQL query, which performs an insert-or-refresh operation but carefully avoids resetting recording-related fields on duplicate keys.
* Updated the registration call in `registerEventIfRelevant` to use `registerMeetRecording` instead of `upsertMeetRecording`, aligning with the new logic.