### PR TITLE
[Meet App] feat: auto-record Meet meetings and attach recordings/transcripts to calendar events

### DIFF
--- a/apps/meet-app/backend/meet_events_service.bal
+++ b/apps/meet-app/backend/meet_events_service.bal
@@ -362,8 +362,12 @@ isolated function processTranscriptReady(string transcriptName) returns error? {
 
     // Best-effort, same reasoning as the recording flow: sharing failures must never fail
     // this function, or a permanent grant failure retries forever, re-attaching and
-    // re-sharing on every retry.
-    driveservice:GrantResult[]|error shareResult = driveservice:grantAccess(fileId, participantEmails, true);
+    // re-sharing on every retry. sendNotificationEmail is false here (unlike recording's
+    // participant grant) -- recording, transcript, and smart notes arrive as three
+    // separate, independently-timed notifications for the same meeting, and participants
+    // already got one "shared with you" email off the recording; access is still granted
+    // silently, discoverable via the calendar event's accumulating attachments.
+    driveservice:GrantResult[]|error shareResult = driveservice:grantAccess(fileId, participantEmails, false);
     if shareResult is error {
         log:printError("Transcript attached, but some participant Drive permission grants failed " +
                 "(best-effort, not retrying).", shareResult);
@@ -427,8 +431,10 @@ isolated function processSmartNotesReady(string smartNotesName) returns error? {
 
     // Best-effort, same reasoning as the other two flows: sharing failures must never
     // fail this function, or a permanent grant failure retries forever, re-attaching and
-    // re-sharing on every retry.
-    driveservice:GrantResult[]|error shareResult = driveservice:grantAccess(fileId, participantEmails, true);
+    // re-sharing on every retry. sendNotificationEmail is false here for the same reason
+    // as processTranscriptReady -- avoid a third "shared with you" email for the same
+    // meeting; access is still granted silently.
+    driveservice:GrantResult[]|error shareResult = driveservice:grantAccess(fileId, participantEmails, false);
     if shareResult is error {
         log:printError("Smart notes attached, but some participant Drive permission grants failed " +
                 "(best-effort, not retrying).", shareResult);

--- a/apps/meet-app/backend/meet_events_service.bal
+++ b/apps/meet-app/backend/meet_events_service.bal
@@ -97,13 +97,14 @@ type PubSubPushEnvelope record {
     string subscription?;
 };
 
-# Meet event notification payload, once decoded -- either a recording-ready or a
-# transcript-ready notification. Google sends one or the other, distinguished by which
-# top-level key is present, never both (the Workspace Events subscription is configured
-# with both event types). Left open for the same reason as PubSubPushEnvelope above.
+# Meet event notification payload, once decoded -- a recording-ready, transcript-ready, or
+# smart-notes-ready notification. Google sends exactly one of these, distinguished by
+# which top-level key is present (the Workspace Events subscription is configured with all
+# three event types). Left open for the same reason as PubSubPushEnvelope above.
 #
 # + recording - Present for a recording-ready notification
 # + transcript - Present for a transcript-ready notification
+# + smartNote - Present for a smart-notes-ready notification
 type MeetEventEnvelope record {
     record {
         string name;
@@ -111,6 +112,9 @@ type MeetEventEnvelope record {
     record {
         string name;
     } transcript?;
+    record {
+        string name;
+    } smartNote?;
 };
 
 # One-off manual registration, for testing without waiting on the Calendar-watch flow --
@@ -202,14 +206,17 @@ service /meet\-events on new http:Listener(meetEventsListenerPort) {
 
         record {string name;}? recording = event?.recording;
         record {string name;}? transcript = event?.transcript;
+        record {string name;}? smartNote = event?.smartNote;
 
         error? result;
         if recording is record {string name;} {
             result = processRecordingReady(recording.name);
         } else if transcript is record {string name;} {
             result = processTranscriptReady(transcript.name);
+        } else if smartNote is record {string name;} {
+            result = processSmartNotesReady(smartNote.name);
         } else {
-            log:printError("Meet event payload had neither 'recording' nor 'transcript'; ignoring.");
+            log:printError("Meet event payload had none of 'recording', 'transcript', 'smartNote'; ignoring.");
             return <http:Ok>{body: {message: "ignored"}};
         }
 
@@ -381,4 +388,69 @@ isolated function processTranscriptReady(string transcriptName) returns error? {
     }
 
     check database:updateMeetTranscript(spaceName, database:ATTACHED, fileId, SYSTEM_ACTOR);
+}
+
+# Mirrors processTranscriptReady, but for smart notes ("Take Notes with Gemini") -- a
+# separate Google Doc artifact, resolved via its own drive-service endpoint and tracked
+# via its own dedicated narrow UPDATE (updateMeetSmartNotes), independent of both
+# recording_state and transcript_state.
+#
+# + smartNotesName - Full resource name of the smart notes
+# + return - Error if a retry-worthy step failed
+isolated function processSmartNotesReady(string smartNotesName) returns error? {
+    driveservice:SmartNotesInfoResponse info = check driveservice:resolveSmartNotes(smartNotesName);
+    string spaceName = info.spaceName;
+    string fileId = info.fileId;
+
+    database:MeetRecordingRow? tracked = check database:getMeetRecordingBySpaceName(spaceName);
+    if tracked is () {
+        log:printError(string `No registered event found for space ${spaceName}; skipping.`);
+        return;
+    }
+
+    error? attachResult = calendar:attachRecording(tracked.organizer, tracked.googleEventId, fileId,
+            "Meeting Notes", "application/vnd.google-apps.document");
+    if attachResult is error {
+        check database:updateMeetSmartNotes(spaceName, database:FAILED, fileId, SYSTEM_ACTOR);
+        return attachResult;
+    }
+
+    string:RegExp commaSplit = re `,`;
+    string[] internalEmails = tracked.internalParticipants.length() > 0
+        ? commaSplit.split(tracked.internalParticipants).map(e => e.trim())
+        : [];
+    // Same internal-only rationale as processRecordingReady/processTranscriptReady:
+    // external participants can't be granted Drive access (cross-domain sharing is
+    // blocked org-wide), so including them here would keep this permanently FAILED and
+    // stuck on Pub/Sub retry.
+    string[] participantEmails = [tracked.organizer, ...internalEmails];
+
+    // Best-effort, same reasoning as the other two flows: sharing failures must never
+    // fail this function, or a permanent grant failure retries forever, re-attaching and
+    // re-sharing on every retry.
+    driveservice:GrantResult[]|error shareResult = driveservice:grantAccess(fileId, participantEmails, true);
+    if shareResult is error {
+        log:printError("Smart notes attached, but some participant Drive permission grants failed " +
+                "(best-effort, not retrying).", shareResult);
+    }
+
+    string[]|error salesDepartmentEmails = people:getSalesDepartmentEmails();
+    if salesDepartmentEmails is error {
+        log:printError("Could not fetch Sales department list; skipping their access grant for these smart notes.",
+                salesDepartmentEmails);
+    } else {
+        string[] extraEmails = [];
+        foreach string email in salesDepartmentEmails {
+            if participantEmails.indexOf(email) == () {
+                extraEmails.push(email);
+            }
+        }
+        driveservice:GrantResult[]|error deptShareResult = driveservice:grantAccess(fileId, extraEmails, false);
+        if deptShareResult is error {
+            log:printError("Smart notes attached, but some Sales department Drive permission grants failed " +
+                    "(best-effort, not retrying).", deptShareResult);
+        }
+    }
+
+    check database:updateMeetSmartNotes(spaceName, database:ATTACHED, fileId, SYSTEM_ACTOR);
 }

--- a/apps/meet-app/backend/meet_events_service.bal
+++ b/apps/meet-app/backend/meet_events_service.bal
@@ -97,14 +97,20 @@ type PubSubPushEnvelope record {
     string subscription?;
 };
 
-# Recording-ready notification payload, once decoded. Left open for the same reason as
-# PubSubPushEnvelope above.
+# Meet event notification payload, once decoded -- either a recording-ready or a
+# transcript-ready notification. Google sends one or the other, distinguished by which
+# top-level key is present, never both (the Workspace Events subscription is configured
+# with both event types). Left open for the same reason as PubSubPushEnvelope above.
 #
-# + recording - The recording this notification is about
-type RecordingReadyEvent record {
+# + recording - Present for a recording-ready notification
+# + transcript - Present for a transcript-ready notification
+type MeetEventEnvelope record {
     record {
         string name;
-    } recording;
+    } recording?;
+    record {
+        string name;
+    } transcript?;
 };
 
 # One-off manual registration, for testing without waiting on the Calendar-watch flow --
@@ -188,16 +194,28 @@ service /meet\-events on new http:Listener(meetEventsListenerPort) {
             log:printError("Decoded Pub/Sub message data was not valid UTF-8.", decodedString);
             return <http:Ok>{body: {message: "ignored"}};
         }
-        RecordingReadyEvent|error event = value:fromJsonStringWithType(decodedString);
+        MeetEventEnvelope|error event = value:fromJsonStringWithType(decodedString);
         if event is error {
-            log:printError("Could not parse recording-ready payload.", event);
+            log:printError("Could not parse Meet event payload.", event);
             return <http:Ok>{body: {message: "ignored"}};
         }
 
-        error? result = processRecordingReady(event.recording.name);
+        record {string name;}? recording = event?.recording;
+        record {string name;}? transcript = event?.transcript;
+
+        error? result;
+        if recording is record {string name;} {
+            result = processRecordingReady(recording.name);
+        } else if transcript is record {string name;} {
+            result = processTranscriptReady(transcript.name);
+        } else {
+            log:printError("Meet event payload had neither 'recording' nor 'transcript'; ignoring.");
+            return <http:Ok>{body: {message: "ignored"}};
+        }
+
         if result is error {
-            log:printError("Failed to process recording-ready event.", result);
-            return <http:ServiceUnavailable>{body: {message: "Failed to process recording-ready event; retry."}};
+            log:printError("Failed to process Meet event.", result);
+            return <http:ServiceUnavailable>{body: {message: "Failed to process Meet event; retry."}};
         }
         return <http:Ok>{body: {message: "ok"}};
     }
@@ -298,4 +316,69 @@ isolated function processRecordingReady(string recordingName) returns error? {
         opportunityId: tracked.opportunityId,
         opportunityDetails: tracked.opportunityDetails
     }, SYSTEM_ACTOR);
+}
+
+# Mirrors processRecordingReady, but for the transcript pipeline: resolves the transcript
+# to its Drive (Google Doc) file, attaches it to the calendar event, shares it, and marks
+# the row's transcript state -- tracked independently of recording_state via a dedicated
+# narrow UPDATE (updateMeetTranscript) rather than the upsert used for recordings, since
+# not every meeting has a transcript and this must never touch the recording columns.
+#
+# + transcriptName - Full resource name of the transcript
+# + return - Error if a retry-worthy step failed
+isolated function processTranscriptReady(string transcriptName) returns error? {
+    driveservice:TranscriptInfoResponse info = check driveservice:resolveTranscript(transcriptName);
+    string spaceName = info.spaceName;
+    string fileId = info.fileId;
+
+    database:MeetRecordingRow? tracked = check database:getMeetRecordingBySpaceName(spaceName);
+    if tracked is () {
+        log:printError(string `No registered event found for space ${spaceName}; skipping.`);
+        return;
+    }
+
+    error? attachResult = calendar:attachRecording(tracked.organizer, tracked.googleEventId, fileId,
+            "Meeting Transcript", "application/vnd.google-apps.document");
+    if attachResult is error {
+        check database:updateMeetTranscript(spaceName, database:FAILED, fileId, SYSTEM_ACTOR);
+        return attachResult;
+    }
+
+    string:RegExp commaSplit = re `,`;
+    string[] internalEmails = tracked.internalParticipants.length() > 0
+        ? commaSplit.split(tracked.internalParticipants).map(e => e.trim())
+        : [];
+    // Same internal-only rationale as processRecordingReady: external participants can't
+    // be granted Drive access (cross-domain sharing is blocked org-wide), so including
+    // them here would keep this permanently FAILED and stuck on Pub/Sub retry.
+    string[] participantEmails = [tracked.organizer, ...internalEmails];
+
+    // Best-effort, same reasoning as the recording flow: sharing failures must never fail
+    // this function, or a permanent grant failure retries forever, re-attaching and
+    // re-sharing on every retry.
+    driveservice:GrantResult[]|error shareResult = driveservice:grantAccess(fileId, participantEmails, true);
+    if shareResult is error {
+        log:printError("Transcript attached, but some participant Drive permission grants failed " +
+                "(best-effort, not retrying).", shareResult);
+    }
+
+    string[]|error salesDepartmentEmails = people:getSalesDepartmentEmails();
+    if salesDepartmentEmails is error {
+        log:printError("Could not fetch Sales department list; skipping their access grant for this transcript.",
+                salesDepartmentEmails);
+    } else {
+        string[] extraEmails = [];
+        foreach string email in salesDepartmentEmails {
+            if participantEmails.indexOf(email) == () {
+                extraEmails.push(email);
+            }
+        }
+        driveservice:GrantResult[]|error deptShareResult = driveservice:grantAccess(fileId, extraEmails, false);
+        if deptShareResult is error {
+            log:printError("Transcript attached, but some Sales department Drive permission grants failed " +
+                    "(best-effort, not retrying).", deptShareResult);
+        }
+    }
+
+    check database:updateMeetTranscript(spaceName, database:ATTACHED, fileId, SYSTEM_ACTOR);
 }

--- a/apps/meet-app/backend/modules/database/db_functions.bal
+++ b/apps/meet-app/backend/modules/database/db_functions.bal
@@ -238,3 +238,16 @@ public isolated function updateMeetTranscript(string spaceName, RecordingState t
         string? transcriptFileId, string actor) returns error? {
     _ = check databaseClient->execute(updateMeetTranscriptQuery(spaceName, transcriptState, transcriptFileId, actor));
 }
+
+# Updates just the smart-notes columns of an existing meeting row, keyed by space name.
+# See updateMeetSmartNotesQuery for why this is a dedicated narrow UPDATE.
+#
+# + spaceName - Resource name of the Meet space, the lookup key
+# + smartNotesState - New smart-notes processing state
+# + smartNotesFileId - Drive file ID (Google Doc) of the smart notes, once resolved
+# + actor - User performing the write
+# + return - Error if the write fails
+public isolated function updateMeetSmartNotes(string spaceName, RecordingState smartNotesState,
+        string? smartNotesFileId, string actor) returns error? {
+    _ = check databaseClient->execute(updateMeetSmartNotesQuery(spaceName, smartNotesState, smartNotesFileId, actor));
+}

--- a/apps/meet-app/backend/modules/database/db_functions.bal
+++ b/apps/meet-app/backend/modules/database/db_functions.bal
@@ -224,3 +224,17 @@ public isolated function getMeetRecordingBySpaceName(string spaceName) returns M
     }
     return result;
 }
+
+# Updates just the transcript columns of an existing meeting row, keyed by space name. See
+# updateMeetTranscriptQuery for why this is a dedicated narrow UPDATE rather than folded
+# into upsertMeetRecording/registerMeetRecording.
+#
+# + spaceName - Resource name of the Meet space, the lookup key
+# + transcriptState - New transcript processing state
+# + transcriptFileId - Drive file ID (Google Doc) of the transcript, once resolved
+# + actor - User performing the write
+# + return - Error if the write fails
+public isolated function updateMeetTranscript(string spaceName, RecordingState transcriptState,
+        string? transcriptFileId, string actor) returns error? {
+    _ = check databaseClient->execute(updateMeetTranscriptQuery(spaceName, transcriptState, transcriptFileId, actor));
+}

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -513,7 +513,34 @@ isolated function getMeetRecordingBySpaceNameQuery(string spaceName) returns sql
         recording_state AS recordingState,
         drive_file_id AS driveFileId,
         opportunity_id AS opportunityId,
-        opportunity_details AS opportunityDetails
+        opportunity_details AS opportunityDetails,
+        transcript_state AS transcriptState,
+        transcript_file_id AS transcriptFileId
     FROM meeting
+    WHERE space_name = ${spaceName}
+`;
+
+# Build a narrow update for just the transcript columns of an existing meeting row, keyed
+# by space_name. Deliberately separate from upsertMeetRecordingQuery/
+# registerMeetRecordingQuery -- folding transcript_state/transcript_file_id into either of
+# those would require re-supplying every recording column too on every write, or risk
+# overwriting them with stale values, which is exactly the class of bug already found once
+# with recording_state (see registerMeetRecordingQuery's doc comment above). A plain
+# UPDATE is enough here since the row is always already registered by calendar-watch by
+# the time a transcript-ready notification can arrive.
+#
+# + spaceName - Resource name of the Meet space, the lookup key
+# + transcriptState - New transcript processing state
+# + transcriptFileId - Drive file ID (Google Doc) of the transcript, once resolved
+# + actor - User performing the write
+# + return - sql:ParameterizedQuery - Update query for the meeting table
+isolated function updateMeetTranscriptQuery(string spaceName, RecordingState transcriptState,
+        string? transcriptFileId, string actor) returns sql:ParameterizedQuery =>
+`
+    UPDATE meeting
+    SET
+        transcript_state = ${transcriptState},
+        transcript_file_id = ${transcriptFileId},
+        updated_by = ${actor}
     WHERE space_name = ${spaceName}
 `;

--- a/apps/meet-app/backend/modules/database/db_queries.bal
+++ b/apps/meet-app/backend/modules/database/db_queries.bal
@@ -515,7 +515,9 @@ isolated function getMeetRecordingBySpaceNameQuery(string spaceName) returns sql
         opportunity_id AS opportunityId,
         opportunity_details AS opportunityDetails,
         transcript_state AS transcriptState,
-        transcript_file_id AS transcriptFileId
+        transcript_file_id AS transcriptFileId,
+        smart_notes_state AS smartNotesState,
+        smart_notes_file_id AS smartNotesFileId
     FROM meeting
     WHERE space_name = ${spaceName}
 `;
@@ -541,6 +543,26 @@ isolated function updateMeetTranscriptQuery(string spaceName, RecordingState tra
     SET
         transcript_state = ${transcriptState},
         transcript_file_id = ${transcriptFileId},
+        updated_by = ${actor}
+    WHERE space_name = ${spaceName}
+`;
+
+# Build a narrow update for just the smart-notes columns of an existing meeting row, keyed
+# by space_name. Same rationale as updateMeetTranscriptQuery -- a separate Google Doc
+# artifact, tracked independently, never folded into the recording/transcript writes.
+#
+# + spaceName - Resource name of the Meet space, the lookup key
+# + smartNotesState - New smart-notes processing state
+# + smartNotesFileId - Drive file ID (Google Doc) of the smart notes, once resolved
+# + actor - User performing the write
+# + return - sql:ParameterizedQuery - Update query for the meeting table
+isolated function updateMeetSmartNotesQuery(string spaceName, RecordingState smartNotesState,
+        string? smartNotesFileId, string actor) returns sql:ParameterizedQuery =>
+`
+    UPDATE meeting
+    SET
+        smart_notes_state = ${smartNotesState},
+        smart_notes_file_id = ${smartNotesFileId},
         updated_by = ${actor}
     WHERE space_name = ${spaceName}
 `;

--- a/apps/meet-app/backend/modules/database/types.bal
+++ b/apps/meet-app/backend/modules/database/types.bal
@@ -219,6 +219,10 @@ public type MeetRecordingPayload record {|
 # arrived yet) -- reuses RecordingState rather than a separate enum with the same member
 # names, which would collide as duplicate module-level constants
 # + transcriptFileId - Drive file ID (Google Doc) of the transcript, if resolved yet
+# + smartNotesState - Current smart-notes processing state, () if no smart notes for this
+# meeting; same reused-RecordingState and NULL-means-"none" semantics as transcriptState
+# + smartNotesFileId - Drive file ID (Google Doc, separate from the transcript's) of the
+# smart notes, if resolved yet
 public type MeetRecordingRow record {|
     int meetingId;
     string spaceName;
@@ -235,4 +239,6 @@ public type MeetRecordingRow record {|
     string? opportunityDetails;
     RecordingState? transcriptState;
     string? transcriptFileId;
+    RecordingState? smartNotesState;
+    string? smartNotesFileId;
 |};

--- a/apps/meet-app/backend/modules/database/types.bal
+++ b/apps/meet-app/backend/modules/database/types.bal
@@ -214,6 +214,11 @@ public type MeetRecordingPayload record {|
 # + driveFileId - Drive file ID of the recording, if resolved yet
 # + opportunityId - Salesforce Opportunity ID this call was scheduled for, if any
 # + opportunityDetails - Compact JSON snapshot of the deal, as a raw JSON string
+# + transcriptState - Current transcript processing state, () if no transcript for this
+# meeting (either transcription wasn't enabled, or no transcript-ready notification has
+# arrived yet) -- reuses RecordingState rather than a separate enum with the same member
+# names, which would collide as duplicate module-level constants
+# + transcriptFileId - Drive file ID (Google Doc) of the transcript, if resolved yet
 public type MeetRecordingRow record {|
     int meetingId;
     string spaceName;
@@ -228,4 +233,6 @@ public type MeetRecordingRow record {|
     string? driveFileId;
     string? opportunityId;
     string? opportunityDetails;
+    RecordingState? transcriptState;
+    string? transcriptFileId;
 |};

--- a/apps/meet-app/backend/modules/driveservice/drive.bal
+++ b/apps/meet-app/backend/modules/driveservice/drive.bal
@@ -48,6 +48,22 @@ public isolated function resolveTranscript(string transcriptName) returns Transc
     return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
 }
 
+# Resolves smart notes (from a smart-notes-ready notification) to its Meet space and
+# Drive (Google Doc) file, via drive-service.
+#
+# + smartNotesName - Full resource name of the smart notes (e.g. `conferenceRecords/abc/smartNotes/xyz`)
+# + return - Space name and Drive file ID, or error
+public isolated function resolveSmartNotes(string smartNotesName) returns SmartNotesInfoResponse|error {
+    string encodedSmartNotesName = check url:encode(smartNotesName, "UTF-8");
+    http:Response response = check driveServiceClient->get(string `/smart-notes?name=${encodedSmartNotesName}`);
+    if response.statusCode == 200 {
+        json responseJson = check response.getJsonPayload();
+        return responseJson.cloneWithType(SmartNotesInfoResponse);
+    }
+    json? errorResponseBody = check response.getJsonPayload();
+    return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
+}
+
 # Grants view access to a recording for each person in the list, via drive-service.
 #
 # + fileId - Drive file ID of the recording

--- a/apps/meet-app/backend/modules/driveservice/drive.bal
+++ b/apps/meet-app/backend/modules/driveservice/drive.bal
@@ -32,6 +32,22 @@ public isolated function resolveRecording(string recordingName) returns Recordin
     return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
 }
 
+# Resolves a transcript (from a transcript-ready notification) to its Meet space and
+# Drive (Google Doc) file, via drive-service.
+#
+# + transcriptName - Full resource name of the transcript (e.g. `conferenceRecords/abc/transcripts/xyz`)
+# + return - Space name and Drive file ID, or error
+public isolated function resolveTranscript(string transcriptName) returns TranscriptInfoResponse|error {
+    string encodedTranscriptName = check url:encode(transcriptName, "UTF-8");
+    http:Response response = check driveServiceClient->get(string `/transcripts?name=${encodedTranscriptName}`);
+    if response.statusCode == 200 {
+        json responseJson = check response.getJsonPayload();
+        return responseJson.cloneWithType(TranscriptInfoResponse);
+    }
+    json? errorResponseBody = check response.getJsonPayload();
+    return error(string `Status: ${response.statusCode}, Response: ${errorResponseBody.toJsonString()}`);
+}
+
 # Grants view access to a recording for each person in the list, via drive-service.
 #
 # + fileId - Drive file ID of the recording

--- a/apps/meet-app/backend/modules/driveservice/types.bal
+++ b/apps/meet-app/backend/modules/driveservice/types.bal
@@ -45,6 +45,15 @@ public type RecordingInfoResponse record {|
     string fileId;
 |};
 
+# Response from resolving a transcript to its space and Drive (Google Doc) file.
+#
+# + spaceName - Resource name of the Meet space (e.g. `spaces/abc123`)
+# + fileId - Drive file ID (Google Doc) of the transcript
+public type TranscriptInfoResponse record {|
+    string spaceName;
+    string fileId;
+|};
+
 # Outcome of granting access to one email.
 #
 # + email - The email a grant was attempted for

--- a/apps/meet-app/backend/modules/driveservice/types.bal
+++ b/apps/meet-app/backend/modules/driveservice/types.bal
@@ -54,6 +54,16 @@ public type TranscriptInfoResponse record {|
     string fileId;
 |};
 
+# Response from resolving smart notes to its space and Drive (Google Doc) file, separate
+# from the transcript's.
+#
+# + spaceName - Resource name of the Meet space (e.g. `spaces/abc123`)
+# + fileId - Drive file ID (Google Doc) of the smart notes
+public type SmartNotesInfoResponse record {|
+    string spaceName;
+    string fileId;
+|};
+
 # Outcome of granting access to one email.
 #
 # + email - The email a grant was attempted for

--- a/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
+++ b/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
@@ -51,6 +51,18 @@ ADD COLUMN `transcript_state` ENUM('PENDING', 'ATTACHED', 'FAILED') NULL;
 ALTER TABLE people_ops_suite.meeting
 ADD COLUMN `transcript_file_id` VARCHAR(255) NULL;
 
+-- Tracks Meet smart-notes ("Take Notes with Gemini") processing, parallel to
+-- transcript_state/transcript_file_id but for a separate Google Doc artifact -- same
+-- NULL-means-"none for this meeting" semantics, since smart notes additionally requires
+-- an org-level admin-console toggle and can silently never arrive even when requested.
+ALTER TABLE people_ops_suite.meeting
+ADD COLUMN `smart_notes_state` ENUM('PENDING', 'ATTACHED', 'FAILED') NULL;
+
+-- Drive file ID (a Google Doc, separate from the transcript's) of the meeting's smart
+-- notes, once resolved.
+ALTER TABLE people_ops_suite.meeting
+ADD COLUMN `smart_notes_file_id` VARCHAR(255) NULL;
+
 
 
 -- Prevents two concurrent upsertMeetRecording calls from ever creating duplicate rows for

--- a/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
+++ b/apps/meet-app/backend/resources/MeetApp_V3_DB_Alteration.sql
@@ -39,6 +39,18 @@ ADD COLUMN `opportunity_id` VARCHAR(255) NULL;
 ALTER TABLE people_ops_suite.meeting
 ADD COLUMN `opportunity_details` JSON NULL;
 
+-- Tracks Meet transcript processing, parallel to recording_state/drive_file_id but
+-- deliberately independent: not every meeting has transcription enabled, so unlike
+-- recording_state (set to PENDING as soon as the meeting is registered), this stays NULL
+-- until an actual transcript-ready notification arrives and sets it directly to ATTACHED
+-- or FAILED. NULL means "no transcript for this meeting", not "waiting on one".
+ALTER TABLE people_ops_suite.meeting
+ADD COLUMN `transcript_state` ENUM('PENDING', 'ATTACHED', 'FAILED') NULL;
+
+-- Drive file ID (a Google Doc) of the meeting's transcript, once resolved.
+ALTER TABLE people_ops_suite.meeting
+ADD COLUMN `transcript_file_id` VARCHAR(255) NULL;
+
 
 
 -- Prevents two concurrent upsertMeetRecording calls from ever creating duplicate rows for


### PR DESCRIPTION
## Summary
Adds the auto-recorded-meetings pipeline: meetings created via the calendar add-on's
"Test Meeting" conferencing option get recorded and (optionally) transcribed
automatically, with the resulting Drive files attached back to the calendar event and
shared with the right people, no manual follow-up required.

## What's new

**Calendar-watch** (`calendar_watch_service.bal`, new)
- Registers a push-notification channel on the Shared Account's calendar via
  calendar-event-service (`watchCalendar`) and polls sync-token based changed events
  (`getChangedEvents`) to catch new/changed meetings.
- Registers each relevant meeting into the `meeting` table, keyed by Meet `space_name`.
- Reads Salesforce opportunity context (`revos_opportunity_id`/`revos_opportunity_snapshot`)
  off the *organizer's own copy* of the event via a new `calendar:getEvent()` call
  (impersonating the organizer through CES's DWD credential) -- private extended properties
  don't propagate to the Shared Account's own (attendee) copy, which the regular sync read
  never sees.

**Meet events ingestion** (`meet_events_service.bal`, new)
- Unauthenticated-at-the-gateway Pub/Sub push listener (Google's push carries no Choreo
  credential), authenticated in-app instead via Google-signed OIDC token verification
  (`verifyPubsubPush`, gated behind `pubsubAuthEnabled` for staged rollout).
- Dispatches recording-ready and transcript-ready Workspace Events notifications to
  `processRecordingReady()` / `processTranscriptReady()`: resolve the Drive file via
  drive-service, attach it to the calendar event via CES, grant Drive view access to
  internal participants plus the Sales/Channel Sales/Sales Engineering departments, and
  track state on the `meeting` row.
- Transcript state (`transcript_state`/`transcript_file_id`) is tracked independently of
  recording state via a dedicated narrow `UPDATE`, deliberately not folded into the
  recording upsert -- not every meeting has transcription enabled, and reusing the same
  write path risked clobbering unrelated columns (the exact bug class already found once
  with `recording_state` during calendar-watch re-registration).

**drive-service client** (`modules/driveservice/`, new module)
- Ballerina HTTP client for the separate drive-service (Go) API: `resolveRecording`,
  `resolveTranscript`, `grantAccess`. Deliberately calls out to a separate service rather
  than widening CES's domain-wide-delegated credential with Drive scope.

**calendar-event-service client additions** (`modules/calendar/meet.bal`)
- `attachRecording`, `watchCalendar`, `getChangedEvents`, `resolveSpaceName`, `getEvent` --
  the CES endpoints this pipeline depends on.

**Database** (`resources/MeetApp_V3_DB_Alteration.sql`)
- New `meeting` columns: `space_name` (unique), `external_participants`, `drive_file_id`,
  `recording_state`, `opportunity_id`, `opportunity_details`, `transcript_state`,
  `transcript_file_id`.
- New `calendar_watch_state` table (stores the sync token between polls).
- `meeting_type` made nullable (auto-recorded rows don't set it; existing scheduling flow
  unaffected).

**people module** (`modules/people/hr.bal`)
- `getSalesDepartmentEmails()`: resolves who should get automatic recording/transcript
  view access, either from a real department lookup or a configurable test-email override
  for staging.

## Test plan
- [x] `bal build` passes clean
- [x] Full pipeline confirmed working end-to-end with real test recordings: calendar-watch
      registration -> Workspace Events/Pub/Sub notification -> attach to calendar event ->
      Drive access shared with participants
- [x] Transcript path verified locally against real Shared Account credentials
      (drive-service `/transcripts` resolves correctly; DB write path unit-verified via
      `bal build`)
